### PR TITLE
Trigger GitHub Actions test workflow on any push to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,8 @@ name: Test invoke-training
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
The GHA workflows are not being triggered on main after a merge. The `$default-branch` placeholder only works in workflow [templates](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow).