### PR TITLE
LoRA training of non-attention UNet layers

### DIFF
--- a/src/invoke_training/training/lora/lora_training.py
+++ b/src/invoke_training/training/lora/lora_training.py
@@ -383,7 +383,7 @@ def run_lora_training(config: LoRATrainingConfig):  # noqa: C901
 
     lora_layers = torch.nn.ModuleDict()
     if config.train_unet:
-        lora_layers["unet"] = inject_lora_into_unet_sd1(unet)
+        lora_layers["unet"] = inject_lora_into_unet_sd1(unet, config.train_unet_non_attention_blocks)
     if config.train_text_encoder:
         lora_layers["text_encoder"] = inject_lora_into_clip_text_encoder(text_encoder)
 

--- a/src/invoke_training/training/lora/lora_training_config.py
+++ b/src/invoke_training/training/lora/lora_training_config.py
@@ -113,6 +113,11 @@ class LoRATrainingConfig(BaseModel):
     # Whether to add LoRA layers to the text encoder and train it.
     train_text_encoder: bool = True
 
+    # Whether to inject LoRA layers into the non-attention UNet blocks for training. Enabling will produce a more
+    # expressive LoRA model at the cost of slower training, higher training VRAM requirements, and a larger LoRA weight
+    # file.
+    train_unet_non_attention_blocks: bool = False
+
     # The number of gradient steps to accumulate before each weight update. This value is passed to Hugging Face
     # Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     gradient_accumulation_steps: int = 1


### PR DESCRIPTION
Add ability to inject LoRA layers into the non-attention blocks of the UNet (specifically the `ResnetBlock2D`, `Downsample2D`, and `Upsample2D`). This matches the kohya_ss behaviour when `conv_dim` is set.

**Manual Testing:**
I trained with this feature for a few epochs and confirmed that the resultant model was sane and can be loaded in InvokeAI. I intend to do more extensive experimentation in the future to better understand the impact of this feature.

- [ ] Merge previous PRs and change target branch to main