### PR TITLE
Add text encoder output caching

### DIFF
--- a/src/invoke_training/training/finetune_lora/finetune_lora_config.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_config.py
@@ -118,6 +118,17 @@ class FinetuneLoRAConfig(BaseModel):
     # file.
     train_unet_non_attention_blocks: bool = False
 
+    # If True, the text encoder(s) will be applied to all of the captions in the dataset before starting training and
+    # the results will be cached to disk. This reduces the VRAM requirements during training (don't have to keep the
+    # text encoders in VRAM), and speeds up training  (don't have to run the text encoders for each training example).
+    # This option can only be enabled if `train_text_encoder == False` and there are no caption augmentations being
+    # applied.
+    cache_text_encoder_outputs: bool = False
+
+    # If True, models will be kept in CPU memory and loaded into GPU memory one-by-one while generating validation
+    # images. This reduces VRAM requirements at the cost of slower generation of validation images.
+    enable_cpu_offload_during_validation: bool = False
+
     # The number of gradient steps to accumulate before each weight update. This value is passed to Hugging Face
     # Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     gradient_accumulation_steps: int = 1

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import os
+import tempfile
 import time
 
 import numpy as np
@@ -358,17 +359,20 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     tokenizer, noise_scheduler, text_encoder, vae, unet = _load_models(config)
 
     # Prepare text encoder output cache.
-    text_encoder_output_cache_dir = None
+    text_encoder_output_cache_dir_name = None
     if config.cache_text_encoder_outputs:
         if config.train_text_encoder:
             raise ValueError("'cache_text_encoder_outputs' and 'train_text_encoder' cannot both be True.")
 
-        text_encoder_output_cache_dir = os.path.join(out_dir, "text_encoder_output_cache")
+        # We use a temporary directory for the cache. The directory will automatically be cleaned up when
+        # tmp_text_encoder_output_cache_dir is destroyed.
+        tmp_text_encoder_output_cache_dir = tempfile.TemporaryDirectory()
+        text_encoder_output_cache_dir_name = tmp_text_encoder_output_cache_dir.name
         if accelerator.is_local_main_process:
             # Only the main process should to populate the cache.
-            logger.info("Generating text encoder output cache.")
+            logger.info(f"Generating text encoder output cache ('{text_encoder_output_cache_dir_name}').")
             text_encoder.to(accelerator.device, dtype=weight_dtype)
-            _cache_text_encoder_outputs(text_encoder_output_cache_dir, config, tokenizer, text_encoder)
+            _cache_text_encoder_outputs(text_encoder_output_cache_dir_name, config, tokenizer, text_encoder)
         # Move the text_encoder back to the CPU, because it is not needed for training.
         text_encoder.to("cpu")
         accelerator.wait_for_everyone()
@@ -393,7 +397,7 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     optimizer = _initialize_optimizer(config, lora_layers.parameters())
 
     data_loader = build_image_caption_sd_dataloader(
-        config.dataset, tokenizer, config.train_batch_size, text_encoder_output_cache_dir
+        config.dataset, tokenizer, config.train_batch_size, text_encoder_output_cache_dir_name
     )
 
     # TODO(ryand): Test in a distributed training environment and more clearly document the rationale for scaling steps

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
@@ -7,6 +7,7 @@ import time
 import numpy as np
 import torch
 from accelerate import Accelerator
+from accelerate.hooks import remove_hook_from_module
 from accelerate.utils import set_seed
 from diffusers import (
     AutoencoderKL,
@@ -39,11 +40,13 @@ from invoke_training.training.shared.checkpoint_tracker import CheckpointTracker
 from invoke_training.training.shared.data.data_loaders.image_caption_sd_dataloader import (
     build_image_caption_sd_dataloader,
 )
+from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
+    TensorDiskCache,
+)
 from invoke_training.training.shared.serialization import save_state_dict
 
 
 def _load_models(
-    accelerator: Accelerator,
     config: FinetuneLoRAConfig,
 ) -> tuple[CLIPTokenizer, DDPMScheduler, CLIPTextModel, AutoencoderKL, UNet2DConditionModel]:
     """Load all models required for training from disk, transfer them to the
@@ -62,8 +65,6 @@ def _load_models(
             UNet2DConditionModel,
         ]: A tuple of loaded models.
     """
-    weight_dtype = get_mixed_precision_dtype(accelerator)
-
     tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(config.model, subfolder="tokenizer")
     noise_scheduler: DDPMScheduler = DDPMScheduler.from_pretrained(config.model, subfolder="scheduler")
     text_encoder: CLIPTextModel = CLIPTextModel.from_pretrained(config.model, subfolder="text_encoder")
@@ -80,10 +81,6 @@ def _load_models(
     vae.eval()
     unet.eval()
 
-    text_encoder.to(accelerator.device, dtype=weight_dtype)
-    vae.to(accelerator.device, dtype=weight_dtype)
-    unet.to(accelerator.device, dtype=weight_dtype)
-
     return tokenizer, noise_scheduler, text_encoder, vae, unet
 
 
@@ -96,6 +93,31 @@ def _initialize_optimizer(config: FinetuneLoRAConfig, trainable_params: list) ->
         weight_decay=config.optimizer.adam_weight_decay,
         eps=config.optimizer.adam_epsilon,
     )
+
+
+def _cache_text_encoder_outputs(
+    cache_dir: str, config: FinetuneLoRAConfig, tokenizer: CLIPTokenizer, text_encoder: CLIPTextModel
+):
+    """Run the text encoder on all captions in the dataset and cache the results to disk.
+
+    Args:
+        cache_dir (str): The directory where the results will be cached.
+        config (FinetuneLoRAConfig): Training config.
+        tokenizer (CLIPTokenizer): The tokenizer.
+        text_encoder (CLIPTextModel): The text_encoder.
+    """
+    data_loader = build_image_caption_sd_dataloader(
+        config.dataset, tokenizer, batch_size=config.train_batch_size, shuffle=False
+    )
+
+    cache = TensorDiskCache(cache_dir)
+
+    for data_batch in tqdm(data_loader):
+        caption_token_ids = data_batch["caption_token_ids"].to(text_encoder.device)
+        text_encoder_output_batch = text_encoder(caption_token_ids)[0]
+        # Split batch before caching.
+        for i in range(len(data_batch["id"])):
+            cache.save(data_batch["id"][i], text_encoder_output_batch[i])
 
 
 def _save_checkpoint(
@@ -159,6 +181,12 @@ def _generate_validation_images(
     """
     logger.info("Generating validation images.")
 
+    # Record original model devices so that we can restore this state after running the pipeline with CPU model
+    # offloading.
+    unet_device = unet.device
+    vae_device = vae.device
+    text_encoder_device = text_encoder.device
+
     # Create pipeline.
     pipeline = StableDiffusionPipeline(
         vae=vae,
@@ -171,7 +199,10 @@ def _generate_validation_images(
         # TODO(ryand): Add safety checker support.
         requires_safety_checker=False,
     )
-    pipeline = pipeline.to(accelerator.device)
+    if config.enable_cpu_offload_during_validation:
+        pipeline.enable_model_cpu_offload(accelerator.device.index or 0)
+    else:
+        pipeline = pipeline.to(accelerator.device)
     pipeline.set_progress_bar_config(disable=True)
 
     # Run inference.
@@ -219,6 +250,17 @@ def _generate_validation_images(
     del pipeline
     torch.cuda.empty_cache()
 
+    # Remove hooks from models.
+    # HACK(ryand): Hooks get added when calling `pipeline.enable_model_cpu_offload(...)`, but `StableDiffusionPipeline`
+    # does not offer a way to clean them up so we have to do this manually.
+    for model in [unet, vae, text_encoder]:
+        remove_hook_from_module(model)
+
+    # Restore models to original devices.
+    unet.to(unet_device)
+    vae.to(vae_device)
+    text_encoder.to(text_encoder_device)
+
 
 def _train_forward(
     config: FinetuneLoRAConfig,
@@ -256,7 +298,10 @@ def _train_forward(
     noisy_latents = noise_scheduler.add_noise(latents, noise, timesteps)
 
     # Get the text embedding for conditioning.
-    encoder_hidden_states = text_encoder(data_batch["caption_token_ids"])[0]
+    # The text_encoder_output may have been cached and included in the data_batch. If not, we calculate it here.
+    encoder_hidden_states = data_batch.get("text_encoder_output", None)
+    if encoder_hidden_states is None:
+        encoder_hidden_states = text_encoder(data_batch["caption_token_ids"])[0]
 
     # Get the target for loss depending on the prediction type.
     if config.prediction_type is not None:
@@ -310,7 +355,28 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     weight_dtype = get_mixed_precision_dtype(accelerator)
 
     logger.info("Loading models.")
-    tokenizer, noise_scheduler, text_encoder, vae, unet = _load_models(accelerator, config)
+    tokenizer, noise_scheduler, text_encoder, vae, unet = _load_models(config)
+
+    # Prepare text encoder output cache.
+    text_encoder_output_cache_dir = None
+    if config.cache_text_encoder_outputs:
+        if config.train_text_encoder:
+            raise ValueError("'cache_text_encoder_outputs' and 'train_text_encoder' cannot both be True.")
+
+        text_encoder_output_cache_dir = os.path.join(out_dir, "text_encoder_output_cache")
+        if accelerator.is_local_main_process:
+            # Only the main process should to populate the cache.
+            logger.info("Generating text encoder output cache.")
+            text_encoder.to(accelerator.device, dtype=weight_dtype)
+            _cache_text_encoder_outputs(text_encoder_output_cache_dir, config, tokenizer, text_encoder)
+        # Move the text_encoder back to the CPU, because it is not needed for training.
+        text_encoder.to("cpu")
+        accelerator.wait_for_everyone()
+    else:
+        text_encoder.to(accelerator.device, dtype=weight_dtype)
+
+    vae.to(accelerator.device, dtype=weight_dtype)
+    unet.to(accelerator.device, dtype=weight_dtype)
 
     lora_layers = torch.nn.ModuleDict()
     if config.train_unet:
@@ -326,7 +392,9 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
 
     optimizer = _initialize_optimizer(config, lora_layers.parameters())
 
-    data_loader = build_image_caption_sd_dataloader(config.dataset, tokenizer, config.train_batch_size)
+    data_loader = build_image_caption_sd_dataloader(
+        config.dataset, tokenizer, config.train_batch_size, text_encoder_output_cache_dir
+    )
 
     # TODO(ryand): Test in a distributed training environment and more clearly document the rationale for scaling steps
     # by the number of processes. This scaling logic was copied from the diffusers example training code, but it appears
@@ -347,7 +415,16 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
         torch.optim.Optimizer,
         torch.utils.data.DataLoader,
         torch.optim.lr_scheduler.LRScheduler,
-    ] = accelerator.prepare(unet, text_encoder, lora_layers, optimizer, data_loader, lr_scheduler)
+    ] = accelerator.prepare(
+        unet,
+        text_encoder,
+        lora_layers,
+        optimizer,
+        data_loader,
+        lr_scheduler,
+        # Disable automatic device placement for text_encoder if the text encoder outputs were cached.
+        device_placement=[True, not config.cache_text_encoder_outputs, True, True, True, True],
+    )
     unet, text_encoder, lora_layers, optimizer, data_loader, lr_scheduler = prepared_result
 
     # Calculate the number of epochs and total training steps. A "step" represents a single weight update operation

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
@@ -24,6 +24,7 @@ def _collate_fn(examples):
     """A batch collation function for the image-caption SDXL data loader."""
     return {
         "image": torch.stack([example["image"] for example in examples]),
+        "id": [example["id"] for example in examples],
         "original_size_hw": [example["original_size_hw"] for example in examples],
         "crop_top_left_yx": [example["crop_top_left_yx"] for example in examples],
         "caption_token_ids_1": torch.stack([example["caption_token_ids_1"] for example in examples]),

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
@@ -1,3 +1,5 @@
+import typing
+
 import torch
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizer
@@ -12,36 +14,62 @@ from invoke_training.training.shared.data.datasets.hf_hub_image_caption_dataset 
 from invoke_training.training.shared.data.datasets.transform_dataset import (
     TransformDataset,
 )
+from invoke_training.training.shared.data.transforms.load_cache_transform import (
+    LoadCacheTransform,
+)
 from invoke_training.training.shared.data.transforms.sd_tokenize_transform import (
     SDTokenizeTransform,
 )
 from invoke_training.training.shared.data.transforms.sdxl_image_transform import (
     SDXLImageTransform,
 )
+from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
+    TensorDiskCache,
+)
 
 
 def _collate_fn(examples):
     """A batch collation function for the image-caption SDXL data loader."""
-    return {
+    out_examples = {
         "image": torch.stack([example["image"] for example in examples]),
         "id": [example["id"] for example in examples],
         "original_size_hw": [example["original_size_hw"] for example in examples],
         "crop_top_left_yx": [example["crop_top_left_yx"] for example in examples],
-        "caption_token_ids_1": torch.stack([example["caption_token_ids_1"] for example in examples]),
-        "caption_token_ids_2": torch.stack([example["caption_token_ids_2"] for example in examples]),
     }
+
+    if "caption_token_ids_1" in examples[0]:
+        out_examples["caption_token_ids_1"] = torch.stack([example["caption_token_ids_1"] for example in examples])
+        out_examples["caption_token_ids_2"] = torch.stack([example["caption_token_ids_2"] for example in examples])
+
+    if "text_encoder_output" in examples[0]:
+        out_examples["text_encoder_output"] = {
+            "prompt_embeds": torch.stack([example["text_encoder_output"]["prompt_embeds"] for example in examples]),
+            "pooled_prompt_embeds": torch.stack(
+                [example["text_encoder_output"]["pooled_prompt_embeds"] for example in examples]
+            ),
+        }
+
+    return out_examples
 
 
 def build_image_caption_sdxl_dataloader(
-    config: DatasetConfig, tokenizer_1: PreTrainedTokenizer, tokenizer_2: PreTrainedTokenizer, batch_size: int
+    config: DatasetConfig,
+    tokenizer_1: PreTrainedTokenizer,
+    tokenizer_2: PreTrainedTokenizer,
+    batch_size: int,
+    text_encoder_output_cache_dir: typing.Optional[str] = None,
+    shuffle: bool = True,
 ) -> DataLoader:
     """Construct a DataLoader for an image-caption dataset for Stable Diffusion XL.
 
     Args:
         config (DatasetConfig): The dataset config.
-        tokenizer (CLIPTokenizer): The tokenizer to apply to the captions.
+        tokenizer (CLIPTokenizer): The tokenizer to apply to the captions. Can be None if
+            `text_encoder_output_cache_dir` is set.
         batch_size (int): The DataLoader batch size.
-
+        text_encoder_output_cache_dir (str, optional): The directory where text encoder outputs are cached and should be
+            loaded from. If set, then the TokenizeTransform will not be applied.
+        shuffle (bool, optional): Whether to shuffle the dataset order.
     Returns:
         DataLoader
     """
@@ -65,21 +93,27 @@ def build_image_caption_sdxl_dataloader(
     else:
         raise ValueError("One of 'dataset_name' or 'dataset_dir' must be set.")
 
-    image_transform = SDXLImageTransform(
-        resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip
-    )
-    tokenize_transform_1 = SDTokenizeTransform(
-        tokenizer_1, src_caption_key="caption", dst_token_key="caption_token_ids_1"
-    )
-    tokenize_transform_2 = SDTokenizeTransform(
-        tokenizer_2, src_caption_key="caption", dst_token_key="caption_token_ids_2"
+    all_transforms = []
+    all_transforms.append(
+        SDXLImageTransform(resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip)
     )
 
-    dataset = TransformDataset(base_dataset, [image_transform, tokenize_transform_1, tokenize_transform_2])
+    if text_encoder_output_cache_dir is None:
+        all_transforms.append(
+            SDTokenizeTransform(tokenizer_1, src_caption_key="caption", dst_token_key="caption_token_ids_1")
+        )
+        all_transforms.append(
+            SDTokenizeTransform(tokenizer_2, src_caption_key="caption", dst_token_key="caption_token_ids_2")
+        )
+    else:
+        cache = TensorDiskCache(text_encoder_output_cache_dir)
+        all_transforms.append(LoadCacheTransform(cache=cache, cache_key_field="id", output_field="text_encoder_output"))
+
+    dataset = TransformDataset(base_dataset, all_transforms)
 
     return DataLoader(
         dataset,
-        shuffle=True,
+        shuffle=shuffle,
         collate_fn=_collate_fn,
         batch_size=batch_size,
         num_workers=config.dataloader_num_workers,

--- a/src/invoke_training/training/shared/data/datasets/hf_dir_image_caption_dataset.py
+++ b/src/invoke_training/training/shared/data/datasets/hf_dir_image_caption_dataset.py
@@ -71,8 +71,11 @@ class HFDirImageCaptionDataset(torch.utils.data.Dataset):
             IndexError: If `idx` is out of range.
 
         Returns:
-            dict: A dataset example with 2 keys: "image", and "caption".
+            dict: A dataset example with 3 keys: "image", "caption", and "id".
                 The "image" key maps to a `PIL` image in RGB format.
                 The "caption" key maps to a string.
+                The "id" key is the example's index (often used for caching).
         """
-        return self._hf_dataset[idx]
+        example = self._hf_dataset[idx]
+        example["id"] = idx
+        return example

--- a/src/invoke_training/training/shared/data/datasets/hf_hub_image_caption_dataset.py
+++ b/src/invoke_training/training/shared/data/datasets/hf_hub_image_caption_dataset.py
@@ -65,8 +65,11 @@ class HFHubImageCaptionDataset(torch.utils.data.Dataset):
             IndexError: If `idx` is out of range.
 
         Returns:
-            dict: A dataset example with 2 keys: "image", and "caption".
+            dict: A dataset example with 3 keys: "image", "caption", and "id".
                 The "image" key maps to a `PIL` image in RGB format.
                 The "caption" key maps to a string.
+                The "id" key is the example's index (often used for caching).
         """
-        return self._hf_dataset[idx]
+        example = self._hf_dataset[idx]
+        example["id"] = idx
+        return example

--- a/src/invoke_training/training/shared/data/transforms/load_cache_transform.py
+++ b/src/invoke_training/training/shared/data/transforms/load_cache_transform.py
@@ -1,0 +1,19 @@
+import typing
+
+from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
+    TensorDiskCache,
+)
+
+
+class LoadCacheTransform:
+    """A transform that loads data from a TensorDiskCache."""
+
+    def __init__(self, cache: TensorDiskCache, cache_key_field: str, output_field: str):
+        self._cache = cache
+        self._cache_key_field = cache_key_field
+        self._output_field = output_field
+
+    def __call__(self, data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        key = data[self._cache_key_field]
+        data[self._output_field] = self._cache.load(hash(key))
+        return data

--- a/src/invoke_training/training/shared/data/transforms/tensor_disk_cache.py
+++ b/src/invoke_training/training/shared/data/transforms/tensor_disk_cache.py
@@ -1,0 +1,44 @@
+import os
+import typing
+
+import torch
+
+
+class TensorDiskCache:
+    """A data cache that caches `torch.Tensor`s on disk."""
+
+    def __init__(self, cache_dir: str):
+        super().__init__()
+        self._cache_dir = cache_dir
+
+        os.makedirs(self._cache_dir, exist_ok=True)
+
+    def _get_path(self, key: int):
+        """Get the cache file path for `key`.
+        Args:
+            key (int): The cache key.
+        Returns:
+            str: The cache file path.
+        """
+        return os.path.join(self._cache_dir, f"{key}.pt")
+
+    def save(self, key: int, data: typing.Dict[str, torch.Tensor]):
+        """Save data in the cache.
+        Raises:
+            AssertionError: If an entry already exists in the cache for this `key`.
+        Args:
+            key (int): The cache key.
+            data (typing.Dict[str, torch.Tensor]): The data to save.
+        """
+        save_path = self._get_path(key)
+        assert not os.path.exists(save_path)
+        torch.save(data, save_path)
+
+    def load(self, key: int) -> typing.Dict[str, torch.Tensor]:
+        """Load data from the cache.
+        Args:
+            key (int): The cache key to load.
+        Returns:
+            typing.Dict[str, torch.Tensor]: Data loaded from the cache.
+        """
+        return torch.load(self._get_path(key))

--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
@@ -29,7 +29,7 @@ def test_build_image_caption_sd_dataloader():
     assert len(data_loader) == math.ceil(833 / 4)
 
     example = next(iter(data_loader))
-    assert set(example.keys()) == {"image", "caption", "caption_token_ids"}
+    assert set(example.keys()) == {"image", "caption", "id", "caption_token_ids"}
 
     image = example["image"]
     assert image.shape == (4, 3, 512, 512)

--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
@@ -35,6 +35,7 @@ def test_build_image_caption_sdxl_dataloader():
     example = next(iter(data_loader))
     assert set(example.keys()) == {
         "image",
+        "id",
         "original_size_hw",
         "crop_top_left_yx",
         "caption_token_ids_1",

--- a/tests/invoke_training/training/shared/data/datasets/test_hf_dir_image_caption_dataset.py
+++ b/tests/invoke_training/training/shared/data/datasets/test_hf_dir_image_caption_dataset.py
@@ -91,7 +91,8 @@ def test_hf_dir_image_caption_dataset_getitem(hf_dir_dataset: HFDirImageCaptionD
     """Test that HFDirImageCaptionDataset.__getitem__(...) returns a valid example."""
     example = hf_dir_dataset[0]
 
-    assert set(example.keys()) == {"image", "caption"}
+    assert set(example.keys()) == {"image", "caption", "id"}
     assert isinstance(example["image"], PIL.Image.Image)
     assert example["image"].mode == "RGB"
     assert isinstance(example["caption"], str)
+    assert example["id"] == 0

--- a/tests/invoke_training/training/shared/data/datasets/test_hf_hub_image_caption_dataset.py
+++ b/tests/invoke_training/training/shared/data/datasets/test_hf_hub_image_caption_dataset.py
@@ -60,7 +60,8 @@ def test_hf_hub_image_caption_dataset_getitem(hf_hub_dataset: HFHubImageCaptionD
     """Test that HFHubImageCaptionDataset.__getitem__(...) returns a valid example."""
     example = hf_hub_dataset[0]
 
-    assert set(example.keys()) == {"image", "caption"}
+    assert set(example.keys()) == {"image", "caption", "id"}
     assert isinstance(example["image"], PIL.Image.Image)
     assert example["image"].mode == "RGB"
     assert isinstance(example["caption"], str)
+    assert example["id"] == 0

--- a/tests/invoke_training/training/shared/data/transforms/test_load_cache_transform.py
+++ b/tests/invoke_training/training/shared/data/transforms/test_load_cache_transform.py
@@ -1,0 +1,22 @@
+import unittest.mock
+
+import torch
+
+from invoke_training.training.shared.data.transforms.load_cache_transform import (
+    LoadCacheTransform,
+)
+
+
+def test_load_cache_transform():
+    cached_tensor = torch.Tensor([1.0, 2.0, 3.0])
+    mock_cache = unittest.mock.MagicMock()
+    mock_cache.load.return_value = cached_tensor
+
+    tf = LoadCacheTransform(cache=mock_cache, cache_key_field="cache_key", output_field="output")
+
+    in_example = {"cache_key": 1}
+
+    out_example = tf(in_example)
+
+    mock_cache.load.assert_called_once_with(1)
+    assert out_example["output"] is cached_tensor

--- a/tests/invoke_training/training/shared/data/transforms/test_tensor_disk_cache.py
+++ b/tests/invoke_training/training/shared/data/transforms/test_tensor_disk_cache.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
+    TensorDiskCache,
+)
+
+
+def test_tensor_disk_cache_roundtrip(tmp_path: Path):
+    """Test a TensorDiskCache cache roundtrip."""
+    cache = TensorDiskCache(str(tmp_path))
+
+    in_dict = {"test_tensor": torch.rand((1, 2, 3))}
+
+    # Roundtrip
+    cache.save(0, in_dict)
+    out_dict = cache.load(0)
+
+    assert set(in_dict.keys()) == set(out_dict.keys())
+    for key in in_dict.keys():
+        torch.testing.assert_close(out_dict[key], in_dict[key])
+
+
+def test_tensor_disk_cache_fail_overwrite(tmp_path):
+    """Test that an attempt to overwrite an existing TensorDiskCache cache entry raises a ValueError."""
+    cache = TensorDiskCache(str(tmp_path))
+    in_dict = {"test_tensor": torch.rand((1, 2, 3))}
+    cache.save(0, in_dict)
+
+    with pytest.raises(AssertionError):
+        cache.save(0, in_dict)


### PR DESCRIPTION
This PR adds support for text encoder output caching to both the SD v1/v2 and SDXL scripts.

Enabling this option significantly reduces the VRAM requirements. I was able to train an SDXL model on an 8GB GPU with this feature (albeit slowly).