### PR TITLE
Add support for gradient checkpointing

### DIFF
--- a/src/invoke_training/training/finetune_lora/finetune_lora_config.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_config.py
@@ -144,7 +144,8 @@ class FinetuneLoRAConfig(BaseModel):
     # If true, use xformers for more efficient attention blocks.
     xformers: bool = False
 
-    # Whether or not to use gradient checkpointing to save memory at the expense of a slower backward pass.
+    # Whether or not to use gradient checkpointing to save memory at the expense of a slower backward pass. Enabling
+    # gradient checkpointing slows down training by ~20%.
     gradient_checkpointing: bool = False
 
     # Total number of training steps to perform. (One training step is one gradient update.)

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
@@ -528,6 +528,25 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
         unet.enable_xformers_memory_efficient_attention()
         vae.enable_xformers_memory_efficient_attention()
 
+    if config.gradient_checkpointing:
+        unet.enable_gradient_checkpointing()
+        # unet must be in train() mode for gradient checkpointing to take effect.
+        # At the time of writing, the unet dropout probabilities default to 0, so putting the unet in train mode does
+        # not change its forward behavior.
+        unet.train()
+        if config.train_text_encoder:
+            for te in [text_encoder_1, text_encoder_2]:
+                te.gradient_checkpointing_enable()
+
+                # The text encoders must be in train() mode for gradient checkpointing to take effect.
+                # At the time of writing, the text encoder dropout probabilities default to 0, so putting the text
+                # encoders in train mode does not change their forward behavior.
+                te.train()
+
+                # Set requires_grad = True on the first parameters of the text encoders. Without this, the text encoder
+                # LoRA weights would have 0 gradients, and so would not get trained.
+                te.text_model.embeddings.requires_grad_(True)
+
     optimizer = _initialize_optimizer(config, lora_layers.parameters())
 
     data_loader = build_image_caption_sdxl_dataloader(


### PR DESCRIPTION
This PR adds support for gradient checkpointing in both SD and SDXL LoRA finetuning. This significantly reduces VRAM requirements at the cost of ~20% slower training.

Note: The `gradient_checkpointing` feature flag already existed, but had no effect.

- [x] Manually tested that SD training with and without gradient checkpointing produces the same result.
- [x] Manually tested that SDXL training with and without gradient checkpointing produces the same result.