### PR TITLE
Add support for VAE output caching

### DIFF
--- a/src/invoke_training/training/finetune_lora/finetune_lora_config.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_config.py
@@ -129,6 +129,12 @@ class FinetuneLoRAConfig(BaseModel):
     # applied.
     cache_text_encoder_outputs: bool = False
 
+    # If True, the VAE will be applied to all of the images in the dataset before starting training and the results will
+    # be cached to disk. This reduces the VRAM requirements during training (don't have to keep the VAE in VRAM), and
+    # speeds up training (don't have to run the VAE encoding step). This option can only be enabled if all
+    # non-deterministic image augmentations are disabled (i.e. center_crop=True, random_flip=False).
+    cache_vae_outputs: bool = False
+
     # If True, models will be kept in CPU memory and loaded into GPU memory one-by-one while generating validation
     # images. This reduces VRAM requirements at the cost of slower generation of validation images.
     enable_cpu_offload_during_validation: bool = False

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
@@ -121,6 +121,29 @@ def _cache_text_encoder_outputs(
             cache.save(data_batch["id"][i], text_encoder_output_batch[i])
 
 
+def _cache_vae_outputs(cache_dir: str, config: FinetuneLoRAConfig, tokenizer: CLIPTokenizer, vae: AutoencoderKL):
+    """Run the VAE on all images in the dataset and cache the results to disk.
+
+    Args:
+        cache_dir (str): The directory where the results will be cached.
+        config (FinetuneLoRAConfig): Training config.
+        tokenizer (CLIPTokenizer): The tokenizer.
+        vae (AutoencoderKL): The VAE.
+    """
+    data_loader = build_image_caption_sd_dataloader(
+        config.dataset, tokenizer, batch_size=config.train_batch_size, shuffle=False
+    )
+
+    cache = TensorDiskCache(cache_dir)
+
+    for data_batch in tqdm(data_loader):
+        latents = vae.encode(data_batch["image"].to(device=vae.device, dtype=vae.dtype)).latent_dist.sample()
+        latents = latents * vae.config.scaling_factor
+        # Split batch before caching.
+        for i in range(len(data_batch["id"])):
+            cache.save(data_batch["id"][i], latents[i])
+
+
 def _save_checkpoint(
     idx: int,
     lora_layers: torch.nn.ModuleDict,
@@ -278,8 +301,11 @@ def _train_forward(
         torch.Tensor: Loss
     """
     # Convert images to latent space.
-    latents = vae.encode(data_batch["image"].to(dtype=weight_dtype)).latent_dist.sample()
-    latents = latents * vae.config.scaling_factor
+    # The VAE output may have been cached and included in the data_batch. If not, we calculate it here.
+    latents = data_batch.get("vae_output", None)
+    if latents is None:
+        latents = vae.encode(data_batch["image"].to(dtype=weight_dtype)).latent_dist.sample()
+        latents = latents * vae.config.scaling_factor
 
     # Sample noise that we'll add to the latents.
     noise = torch.randn_like(latents)
@@ -358,6 +384,12 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = _load_models(config)
 
+    if config.xformers:
+        import xformers  # noqa: F401
+
+        unet.enable_xformers_memory_efficient_attention()
+        vae.enable_xformers_memory_efficient_attention()
+
     # Prepare text encoder output cache.
     text_encoder_output_cache_dir_name = None
     if config.cache_text_encoder_outputs:
@@ -369,7 +401,7 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
         tmp_text_encoder_output_cache_dir = tempfile.TemporaryDirectory()
         text_encoder_output_cache_dir_name = tmp_text_encoder_output_cache_dir.name
         if accelerator.is_local_main_process:
-            # Only the main process should to populate the cache.
+            # Only the main process should populate the cache.
             logger.info(f"Generating text encoder output cache ('{text_encoder_output_cache_dir_name}').")
             text_encoder.to(accelerator.device, dtype=weight_dtype)
             _cache_text_encoder_outputs(text_encoder_output_cache_dir_name, config, tokenizer, text_encoder)
@@ -379,7 +411,29 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     else:
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
-    vae.to(accelerator.device, dtype=weight_dtype)
+    # Prepare VAE output cache.
+    vae_output_cache_dir_name = None
+    if config.cache_vae_outputs:
+        if config.dataset.random_flip:
+            raise ValueError("'cache_vae_outputs' cannot be True if 'random_flip' is True.")
+        if not config.dataset.center_crop:
+            raise ValueError("'cache_vae_outputs' cannot be True if 'center_crop' is False.")
+
+        # We use a temporary directory for the cache. The directory will automatically be cleaned up when
+        # tmp_vae_output_cache_dir is destroyed.
+        tmp_vae_output_cache_dir = tempfile.TemporaryDirectory()
+        vae_output_cache_dir_name = tmp_vae_output_cache_dir.name
+        if accelerator.is_local_main_process:
+            # Only the main process should to populate the cache.
+            logger.info(f"Generating VAE output cache ('{vae_output_cache_dir_name}').")
+            vae.to(accelerator.device, dtype=weight_dtype)
+            _cache_vae_outputs(vae_output_cache_dir_name, config, tokenizer, vae)
+        # Move the VAE back to the CPU, because it is not needed for training.
+        vae.to("cpu")
+        accelerator.wait_for_everyone()
+    else:
+        vae.to(accelerator.device, dtype=weight_dtype)
+
     unet.to(accelerator.device, dtype=weight_dtype)
 
     lora_layers = torch.nn.ModuleDict()
@@ -392,16 +446,14 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
             text_encoder, lora_rank_dim=config.lora_rank_dim
         )
 
-    if config.xformers:
-        import xformers  # noqa: F401
-
-        unet.enable_xformers_memory_efficient_attention()
-        vae.enable_xformers_memory_efficient_attention()
-
     optimizer = _initialize_optimizer(config, lora_layers.parameters())
 
     data_loader = build_image_caption_sd_dataloader(
-        config.dataset, tokenizer, config.train_batch_size, text_encoder_output_cache_dir_name
+        config.dataset,
+        tokenizer,
+        config.train_batch_size,
+        text_encoder_output_cache_dir_name,
+        vae_output_cache_dir_name,
     )
 
     # TODO(ryand): Test in a distributed training environment and more clearly document the rationale for scaling steps

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -32,6 +32,7 @@ def build_image_caption_sd_dataloader(
     tokenizer: typing.Optional[CLIPTokenizer],
     batch_size: int,
     text_encoder_output_cache_dir: typing.Optional[str] = None,
+    vae_output_cache_dir: typing.Optional[str] = None,
     shuffle: bool = True,
 ) -> DataLoader:
     """Construct a DataLoader for an image-caption dataset for Stable Diffusion v1/v2..
@@ -43,6 +44,7 @@ def build_image_caption_sd_dataloader(
         batch_size (int): The DataLoader batch size.
         text_encoder_output_cache_dir (str, optional): The directory where text encoder outputs are cached and should be
             loaded from. If set, then the TokenizeTransform will not be applied.
+        vae_output_cache_dir (str, optional): The directory where VAE outputs are cached and should be loaded from.
         shuffle (bool, optional): Whether to shuffle the dataset order.
     Returns:
         DataLoader
@@ -68,17 +70,24 @@ def build_image_caption_sd_dataloader(
     else:
         raise ValueError("One of 'dataset_name' or 'dataset_dir' must be set.")
 
-    image_transform = SDImageTransform(
-        resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip
+    all_transforms = []
+    all_transforms.append(
+        SDImageTransform(resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip)
     )
 
     if text_encoder_output_cache_dir is None:
-        caption_transform = SDTokenizeTransform(tokenizer)
+        all_transforms.append(SDTokenizeTransform(tokenizer))
     else:
-        cache = TensorDiskCache(text_encoder_output_cache_dir)
-        caption_transform = LoadCacheTransform(cache=cache, cache_key_field="id", output_field="text_encoder_output")
+        text_encoder_cache = TensorDiskCache(text_encoder_output_cache_dir)
+        all_transforms.append(
+            LoadCacheTransform(cache=text_encoder_cache, cache_key_field="id", output_field="text_encoder_output")
+        )
 
-    dataset = TransformDataset(base_dataset, [image_transform, caption_transform])
+    if vae_output_cache_dir is not None:
+        vae_cache = TensorDiskCache(vae_output_cache_dir)
+        all_transforms.append(LoadCacheTransform(cache=vae_cache, cache_key_field="id", output_field="vae_output"))
+
+    dataset = TransformDataset(base_dataset, all_transforms)
 
     return DataLoader(
         dataset,

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
@@ -14,6 +14,9 @@ from invoke_training.training.shared.data.datasets.hf_hub_image_caption_dataset 
 from invoke_training.training.shared.data.datasets.transform_dataset import (
     TransformDataset,
 )
+from invoke_training.training.shared.data.transforms.drop_field_transform import (
+    DropFieldTransform,
+)
 from invoke_training.training.shared.data.transforms.load_cache_transform import (
     LoadCacheTransform,
 )
@@ -31,11 +34,13 @@ from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
 def _collate_fn(examples):
     """A batch collation function for the image-caption SDXL data loader."""
     out_examples = {
-        "image": torch.stack([example["image"] for example in examples]),
         "id": [example["id"] for example in examples],
-        "original_size_hw": [example["original_size_hw"] for example in examples],
-        "crop_top_left_yx": [example["crop_top_left_yx"] for example in examples],
     }
+
+    if "image" in examples[0]:
+        out_examples["image"] = torch.stack([example["image"] for example in examples])
+        out_examples["original_size_hw"] = [example["original_size_hw"] for example in examples]
+        out_examples["crop_top_left_yx"] = [example["crop_top_left_yx"] for example in examples]
 
     if "caption_token_ids_1" in examples[0]:
         out_examples["caption_token_ids_1"] = torch.stack([example["caption_token_ids_1"] for example in examples])
@@ -73,7 +78,8 @@ def build_image_caption_sdxl_dataloader(
         batch_size (int): The DataLoader batch size.
         text_encoder_output_cache_dir (str, optional): The directory where text encoder outputs are cached and should be
             loaded from. If set, then the TokenizeTransform will not be applied.
-        vae_output_cache_dir (str, optional): The directory where VAE outputs are cached and should be loaded from.
+        vae_output_cache_dir (str, optional): The directory where VAE outputs are cached and should be loaded from. If
+            set, then the image augmentation transforms will be skipped, and the image will not be copied to VRAM.
         shuffle (bool, optional): Whether to shuffle the dataset order.
     Returns:
         DataLoader
@@ -99,9 +105,17 @@ def build_image_caption_sdxl_dataloader(
         raise ValueError("One of 'dataset_name' or 'dataset_dir' must be set.")
 
     all_transforms = []
-    all_transforms.append(
-        SDXLImageTransform(resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip)
-    )
+    if vae_output_cache_dir is None:
+        all_transforms.append(
+            SDXLImageTransform(
+                resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip
+            )
+        )
+    else:
+        vae_cache = TensorDiskCache(vae_output_cache_dir)
+        all_transforms.append(LoadCacheTransform(cache=vae_cache, cache_key_field="id", output_field="vae_output"))
+        # We drop the image to avoid having to either convert from PIL, or handle PIL batch collation.
+        all_transforms.append(DropFieldTransform("image"))
 
     if text_encoder_output_cache_dir is None:
         all_transforms.append(
@@ -115,10 +129,6 @@ def build_image_caption_sdxl_dataloader(
         all_transforms.append(
             LoadCacheTransform(cache=text_encoder_cache, cache_key_field="id", output_field="text_encoder_output")
         )
-
-    if vae_output_cache_dir is not None:
-        vae_cache = TensorDiskCache(vae_output_cache_dir)
-        all_transforms.append(LoadCacheTransform(cache=vae_cache, cache_key_field="id", output_field="vae_output"))
 
     dataset = TransformDataset(base_dataset, all_transforms)
 

--- a/src/invoke_training/training/shared/data/transforms/drop_field_transform.py
+++ b/src/invoke_training/training/shared/data/transforms/drop_field_transform.py
@@ -1,0 +1,12 @@
+import typing
+
+
+class DropFieldTransform:
+    """A simple transform that drops a field from an example."""
+
+    def __init__(self, field_to_drop: str):
+        self._field_to_drop = field_to_drop
+
+    def __call__(self, data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        del data[self._field_to_drop]
+        return data

--- a/tests/invoke_training/training/shared/data/transforms/test_drop_field_transform.py
+++ b/tests/invoke_training/training/shared/data/transforms/test_drop_field_transform.py
@@ -1,0 +1,13 @@
+from invoke_training.training.shared.data.transforms.drop_field_transform import (
+    DropFieldTransform,
+)
+
+
+def test_drop_field_transform():
+    tf = DropFieldTransform("drop")
+
+    in_example = {"keep": 1, "drop": 2}
+
+    out_example = tf(in_example)
+
+    assert out_example == {"keep": 1}


### PR DESCRIPTION
Adds VAE output caching. This reduces the training VRAM requirements _slightly_, and improves training speed by ~20%.