### PR TITLE
Fix bug with `cache_vae_outputs` and SDXL

### DIFF
--- a/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
@@ -106,7 +106,7 @@ def _cache_text_encoder_outputs(
         text_encoder_output_batch = text_encoder(caption_token_ids)[0]
         # Split batch before caching.
         for i in range(len(data_batch["id"])):
-            cache.save(data_batch["id"][i], text_encoder_output_batch[i])
+            cache.save(data_batch["id"][i], {"text_encoder_output": text_encoder_output_batch[i]})
 
 
 def _cache_vae_outputs(cache_dir: str, config: FinetuneLoRAConfig, tokenizer: CLIPTokenizer, vae: AutoencoderKL):
@@ -129,7 +129,7 @@ def _cache_vae_outputs(cache_dir: str, config: FinetuneLoRAConfig, tokenizer: CL
         latents = latents * vae.config.scaling_factor
         # Split batch before caching.
         for i in range(len(data_batch["id"])):
-            cache.save(data_batch["id"][i], latents[i])
+            cache.save(data_batch["id"][i], {"vae_output": latents[i]})
 
 
 def _save_checkpoint(

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -83,7 +83,11 @@ def build_image_caption_sd_dataloader(
         )
     else:
         vae_cache = TensorDiskCache(vae_output_cache_dir)
-        all_transforms.append(LoadCacheTransform(cache=vae_cache, cache_key_field="id", output_field="vae_output"))
+        all_transforms.append(
+            LoadCacheTransform(
+                cache=vae_cache, cache_key_field="id", cache_field_to_output_field={"vae_output": "vae_output"}
+            )
+        )
         # We drop the image to avoid having to either convert from PIL, or handle PIL batch collation.
         all_transforms.append(DropFieldTransform("image"))
 
@@ -92,7 +96,11 @@ def build_image_caption_sd_dataloader(
     else:
         text_encoder_cache = TensorDiskCache(text_encoder_output_cache_dir)
         all_transforms.append(
-            LoadCacheTransform(cache=text_encoder_cache, cache_key_field="id", output_field="text_encoder_output")
+            LoadCacheTransform(
+                cache=text_encoder_cache,
+                cache_key_field="id",
+                cache_field_to_output_field={"text_encoder_output": "text_encoder_output"},
+            )
         )
 
     dataset = TransformDataset(base_dataset, all_transforms)

--- a/src/invoke_training/training/shared/data/transforms/load_cache_transform.py
+++ b/src/invoke_training/training/shared/data/transforms/load_cache_transform.py
@@ -8,12 +8,27 @@ from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
 class LoadCacheTransform:
     """A transform that loads data from a TensorDiskCache."""
 
-    def __init__(self, cache: TensorDiskCache, cache_key_field: str, output_field: str):
+    def __init__(
+        self, cache: TensorDiskCache, cache_key_field: str, cache_field_to_output_field: typing.Dict[str, str]
+    ):
+        """Initialize LoadCacheTransform.
+
+        Args:
+            cache (TensorDiskCache): The cache to load from.
+            cache_key_field (str): The name of the field to use as the cache key.
+            cache_field_to_output_field (typing.Dict[str, str]): A map of field names in the cached data to the field
+                names where they should be inserted in the example data.
+        """
         self._cache = cache
         self._cache_key_field = cache_key_field
-        self._output_field = output_field
+        self._cache_field_to_output_field = cache_field_to_output_field
 
     def __call__(self, data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
         key = data[self._cache_key_field]
-        data[self._output_field] = self._cache.load(hash(key))
+
+        cache_data = self._cache.load(hash(key))
+
+        for src, dst in self._cache_field_to_output_field.items():
+            data[dst] = cache_data[src]
+
         return data

--- a/src/invoke_training/training/shared/data/transforms/tensor_disk_cache.py
+++ b/src/invoke_training/training/shared/data/transforms/tensor_disk_cache.py
@@ -30,6 +30,10 @@ class TensorDiskCache:
             key (int): The cache key.
             data (typing.Dict[str, torch.Tensor]): The data to save.
         """
+        # torch.save() supports a range of different data types, but it is cleaner if we force everyone to use a dict.
+        # This allows for more reusable cache loading code.
+        assert isinstance(data, dict)
+
         save_path = self._get_path(key)
         assert not os.path.exists(save_path)
         torch.save(data, save_path)

--- a/tests/invoke_training/training/shared/data/transforms/test_load_cache_transform.py
+++ b/tests/invoke_training/training/shared/data/transforms/test_load_cache_transform.py
@@ -10,9 +10,11 @@ from invoke_training.training.shared.data.transforms.load_cache_transform import
 def test_load_cache_transform():
     cached_tensor = torch.Tensor([1.0, 2.0, 3.0])
     mock_cache = unittest.mock.MagicMock()
-    mock_cache.load.return_value = cached_tensor
+    mock_cache.load.return_value = {"cached_tensor": cached_tensor}
 
-    tf = LoadCacheTransform(cache=mock_cache, cache_key_field="cache_key", output_field="output")
+    tf = LoadCacheTransform(
+        cache=mock_cache, cache_key_field="cache_key", cache_field_to_output_field={"cached_tensor": "output"}
+    )
 
     in_example = {"cache_key": 1}
 

--- a/tests/invoke_training/training/shared/data/transforms/test_tensor_disk_cache.py
+++ b/tests/invoke_training/training/shared/data/transforms/test_tensor_disk_cache.py
@@ -12,15 +12,17 @@ def test_tensor_disk_cache_roundtrip(tmp_path: Path):
     """Test a TensorDiskCache cache roundtrip."""
     cache = TensorDiskCache(str(tmp_path))
 
-    in_dict = {"test_tensor": torch.rand((1, 2, 3))}
+    in_dict = {"test_tensor": torch.rand((1, 2, 3)), "test_tuple": (1, 2), "test_list": [3, 4], "test_scalar": 1}
 
     # Roundtrip
     cache.save(0, in_dict)
     out_dict = cache.load(0)
 
     assert set(in_dict.keys()) == set(out_dict.keys())
-    for key in in_dict.keys():
-        torch.testing.assert_close(out_dict[key], in_dict[key])
+    torch.testing.assert_close(out_dict["test_tensor"], in_dict["test_tensor"])
+    assert out_dict["test_tuple"] == in_dict["test_tuple"]
+    assert out_dict["test_list"] == in_dict["test_list"]
+    assert out_dict["test_scalar"] == in_dict["test_scalar"]
 
 
 def test_tensor_disk_cache_fail_overwrite(tmp_path):


### PR DESCRIPTION
Prior to this fix, when `cache_vae_outputs` was enabled when training with SDXL, an exception would be raised because `original_size_hw` and `crop_top_left_yx`. This change caches those fields along with the vae_outputs.

- [x] Tested SD v1, `cache_vae_outputs=True`, `cache_text_encoder_outputs=True`
- [x] Tested SD v1, `cache_vae_outputs=False`, `cache_text_encoder_outputs=False`
- [x] Tested SDXL, `cache_vae_outputs=True`, `cache_text_encoder_outputs=True`
- [x] Tested SDXL, `cache_vae_outputs=False`, `cache_text_encoder_outputs=False`