### PR TITLE
Preparation for DreamBooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ A library for training custom Stable Diffusion models (fine-tuning, LoRA trainin
 
 ## Training Modes
 
-There are currently 2 supported training scripts:
 - Finetune with LoRA
     - Stable Diffusion v1/v2: `invoke-finetune-lora-sd`
     - Stable Diffusion XL: `invoke-finetune-lora-sdxl`
+- DreamBooth with LoRA
+    - Stable Diffusion v1/v2: `invoke-dreambooth-lora-sd`
+    - Stable Diffusion XL:  `invoke-dreambooth-lora-sdxl`
 
 More training modes will be added soon.
 

--- a/configs/finetune_lora_sd_pokemon_1x8gb_example.yaml
+++ b/configs/finetune_lora_sd_pokemon_1x8gb_example.yaml
@@ -21,7 +21,8 @@ optimizer:
 
 dataset:
   dataset_name: lambdalabs/pokemon-blip-captions
-  resolution: 512
+  image_transforms:
+    resolution: 512
 
 # General
 model: runwayml/stable-diffusion-v1-5

--- a/configs/finetune_lora_sdxl_pokemon_1x24gb_example.yaml
+++ b/configs/finetune_lora_sdxl_pokemon_1x24gb_example.yaml
@@ -21,7 +21,8 @@ optimizer:
 
 dataset:
   dataset_name: lambdalabs/pokemon-blip-captions
-  resolution: 512
+  image_transforms:
+    resolution: 512
 
 # General
 model: stabilityai/stable-diffusion-xl-base-1.0

--- a/configs/finetune_lora_sdxl_pokemon_1x8gb_example.yaml
+++ b/configs/finetune_lora_sdxl_pokemon_1x8gb_example.yaml
@@ -22,7 +22,8 @@ optimizer:
 
 dataset:
   dataset_name: lambdalabs/pokemon-blip-captions
-  resolution: 512
+  image_transforms:
+    resolution: 512
 
 # General
 model: stabilityai/stable-diffusion-xl-base-1.0

--- a/docs/dataset_formats.md
+++ b/docs/dataset_formats.md
@@ -21,7 +21,7 @@ dataset:
 # ...
 ```
 
-See [lora_training_config.py](/src/invoke_training/training/lora/lora_training_config.py) for full documentation of the `DatasetConfig`.
+See [data_config.py](/src/invoke_training/training/config/data_config.py) for full documentation of the `ImageCaptionDatasetConfig`.
 
 ### ImageFolder Datasets
 If you want to create custom datasets, then you will most likely want to use the [ImageFolder](https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder) dataset format.
@@ -57,4 +57,4 @@ dataset:
 # ...
 ```
 
-See [lora_training_config.py](/src/invoke_training/training/lora/lora_training_config.py) for full documentation of the `DatasetConfig`.
+See [data_config.py](/src/invoke_training/training/config/data_config.py) for full documentation of the `ImageCaptionDatasetConfig`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
 [project.scripts]
 "invoke-finetune-lora-sd" = "invoke_training.scripts.invoke_finetune_lora_sd:main"
 "invoke-finetune-lora-sdxl" = "invoke_training.scripts.invoke_finetune_lora_sdxl:main"
+"invoke-dreambooth-lora-sd" = "invoke_training.scripts.invoke_dreambooth_lora_sd:main"
+"invoke-dreambooth-lora-sdxl" = "invoke_training.scripts.invoke_dreambooth_lora_sdxl:main"
 
 [project.urls]
 "Homepage" = "https://github.com/invoke-ai/invoke-training"

--- a/src/invoke_training/scripts/invoke_dreambooth_lora_sd.py
+++ b/src/invoke_training/scripts/invoke_dreambooth_lora_sd.py
@@ -1,0 +1,36 @@
+import argparse
+from pathlib import Path
+
+import yaml
+
+from invoke_training.training.config.finetune_lora_config import DreamBoothLoRAConfig
+from invoke_training.training.dreambooth_lora.dreambooth_lora_sd import run_training
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="DreamBooth training with LoRA for Stable Diffusion v1 and v2 base models."
+    )
+    parser.add_argument(
+        "--cfg-file",
+        type=Path,
+        required=True,
+        help="Path to the YAML training config file. See `DreamBoothLoRAConfig` for the supported fields.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Load YAML config file.
+    with open(args.cfg_file, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    train_config = DreamBoothLoRAConfig(**cfg)
+
+    run_training(train_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/invoke_training/scripts/invoke_dreambooth_lora_sdxl.py
+++ b/src/invoke_training/scripts/invoke_dreambooth_lora_sdxl.py
@@ -1,0 +1,36 @@
+import argparse
+from pathlib import Path
+
+import yaml
+
+from invoke_training.training.config.finetune_lora_config import (
+    DreamBoothLoRASDXLConfig,
+)
+from invoke_training.training.dreambooth_lora.dreambooth_lora_sd import run_training
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="DreamBooth training with LoRA for Stable Diffusion XL base models.")
+    parser.add_argument(
+        "--cfg-file",
+        type=Path,
+        required=True,
+        help="Path to the YAML training config file. See `DreamBoothLoRASDXLConfig` for the supported fields.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Load YAML config file.
+    with open(args.cfg_file, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    train_config = DreamBoothLoRASDXLConfig(**cfg)
+
+    run_training(train_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/invoke_training/training/config/data_config.py
+++ b/src/invoke_training/training/config/data_config.py
@@ -3,6 +3,18 @@ import typing
 from pydantic import BaseModel
 
 
+class ImageTransformConfig(BaseModel):
+    # The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
+    resolution: int = 512
+
+    # If True, input images will be center-cropped to resolution.
+    # If False, input images will be randomly cropped to resolution.
+    center_crop: bool = False
+
+    # Whether random flip augmentations should be applied to input images.
+    random_flip: bool = False
+
+
 class ImageCaptionDatasetConfig(BaseModel):
     # The name of a Hugging Face dataset.
     # One of dataset_name and dataset_dir should be set (dataset_name takes precedence).
@@ -28,15 +40,18 @@ class ImageCaptionDatasetConfig(BaseModel):
     # The name of the dataset column that contains captions.
     caption_column: str = "text"
 
-    # The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
-    resolution: int = 512
-
-    # If True, input images will be center-cropped to resolution.
-    # If False, input images will be randomly cropped to resolution.
-    center_crop: bool = False
-
-    # Whether random flip augmentations should be applied to input images.
-    random_flip: bool = False
-
     # Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
     dataloader_num_workers: int = 0
+
+    image_transforms: ImageTransformConfig
+
+
+class ImageDirDatasetConfig(BaseModel):
+    # The directory to load images from.
+    dataset_dir: str
+
+    # The image file extensions to include in the dataset.
+    # If None, then the following file extensions will be loaded: [".png", ".jpg", ".jpeg"].
+    image_file_extensions: typing.Optional[list[str]] = None
+
+    image_transforms: ImageTransformConfig

--- a/src/invoke_training/training/config/data_config.py
+++ b/src/invoke_training/training/config/data_config.py
@@ -1,0 +1,42 @@
+import typing
+
+from pydantic import BaseModel
+
+
+class ImageCaptionDatasetConfig(BaseModel):
+    # The name of a Hugging Face dataset.
+    # One of dataset_name and dataset_dir should be set (dataset_name takes precedence).
+    # See also: dataset_config_name.
+    dataset_name: typing.Optional[str] = None
+
+    # The directory to load a dataset from. The dataset is expected to be in
+    # Hugging Face imagefolder format (https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder).
+    # One of 'dataset_name' and 'dataset_dir' should be set ('dataset_name' takes precedence).
+    dataset_dir: typing.Optional[str] = None
+
+    # The Hugging Face dataset config name. Leave as None if there's only one config.
+    # This parameter is only used if dataset_name is set.
+    dataset_config_name: typing.Optional[str] = None
+
+    # The Hugging Face cache directory to use for dataset downloads.
+    # If None, the default value will be used (usually '~/.cache/huggingface/datasets').
+    hf_cache_dir: typing.Optional[str] = None
+
+    # The name of the dataset column that contains image paths.
+    image_column: str = "image"
+
+    # The name of the dataset column that contains captions.
+    caption_column: str = "text"
+
+    # The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
+    resolution: int = 512
+
+    # If True, input images will be center-cropped to resolution.
+    # If False, input images will be randomly cropped to resolution.
+    center_crop: bool = False
+
+    # Whether random flip augmentations should be applied to input images.
+    random_flip: bool = False
+
+    # Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
+    dataloader_num_workers: int = 0

--- a/src/invoke_training/training/config/finetune_lora_config.py
+++ b/src/invoke_training/training/config/finetune_lora_config.py
@@ -2,7 +2,10 @@ import typing
 
 from pydantic import BaseModel
 
-from invoke_training.training.config.data_config import ImageCaptionDatasetConfig
+from invoke_training.training.config.data_config import (
+    ImageCaptionDatasetConfig,
+    ImageDirDatasetConfig,
+)
 from invoke_training.training.config.optimizer_config import OptimizerConfig
 
 
@@ -136,7 +139,7 @@ class DreamBoothLoRAConfig(LoRATrainingConfig):
     optimizer: OptimizerConfig
 
     # The instance dataset to train on.
-    instance_dataset: ImageCaptionDatasetConfig
+    instance_dataset: ImageDirDatasetConfig
 
     # The caption to use for all examples in the instance_dataset. Typically has the following form:
     # "a [instance identifier] [class noun]".

--- a/src/invoke_training/training/config/finetune_lora_config.py
+++ b/src/invoke_training/training/config/finetune_lora_config.py
@@ -2,6 +2,7 @@ import typing
 
 from pydantic import BaseModel
 
+from invoke_training.training.config.data_config import ImageCaptionDatasetConfig
 from invoke_training.training.config.optimizer_config import OptimizerConfig
 
 
@@ -24,45 +25,6 @@ class TrainingOutputConfig(BaseModel):
     save_model_as: typing.Literal["ckpt", "pt", "safetensors"] = "safetensors"
 
 
-class DatasetConfig(BaseModel):
-    # The name of a Hugging Face dataset.
-    # One of dataset_name and dataset_dir should be set (dataset_name takes precedence).
-    # See also: dataset_config_name.
-    dataset_name: typing.Optional[str] = None
-
-    # The directory to load a dataset from. The dataset is expected to be in
-    # Hugging Face imagefolder format (https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder).
-    # One of 'dataset_name' and 'dataset_dir' should be set ('dataset_name' takes precedence).
-    dataset_dir: typing.Optional[str] = None
-
-    # The Hugging Face dataset config name. Leave as None if there's only one config.
-    # This parameter is only used if dataset_name is set.
-    dataset_config_name: typing.Optional[str] = None
-
-    # The Hugging Face cache directory to use for dataset downloads.
-    # If None, the default value will be used (usually '~/.cache/huggingface/datasets').
-    hf_cache_dir: typing.Optional[str] = None
-
-    # The name of the dataset column that contains image paths.
-    image_column: str = "image"
-
-    # The name of the dataset column that contains captions.
-    caption_column: str = "text"
-
-    # The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
-    resolution: int = 512
-
-    # If True, input images will be center-cropped to resolution.
-    # If False, input images will be randomly cropped to resolution.
-    center_crop: bool = False
-
-    # Whether random flip augmentations should be applied to input images.
-    random_flip: bool = False
-
-    # Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
-    dataloader_num_workers: int = 0
-
-
 class FinetuneLoRAConfig(BaseModel):
     """The configuration for a LoRA training run."""
 
@@ -70,7 +32,7 @@ class FinetuneLoRAConfig(BaseModel):
 
     optimizer: OptimizerConfig
 
-    dataset: DatasetConfig
+    dataset: ImageCaptionDatasetConfig
 
     ##################
     # General Configs

--- a/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sd.py
+++ b/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sd.py
@@ -1,0 +1,5 @@
+from invoke_training.training.config.finetune_lora_config import DreamBoothLoRAConfig
+
+
+def run_training(config: DreamBoothLoRAConfig):
+    raise NotImplementedError

--- a/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sdxl.py
+++ b/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sdxl.py
@@ -1,0 +1,7 @@
+from invoke_training.training.config.finetune_lora_config import (
+    DreamBoothLoRASDXLConfig,
+)
+
+
+def run_training(config: DreamBoothLoRASDXLConfig):
+    raise NotImplementedError

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sd.py
@@ -232,8 +232,8 @@ def _generate_validation_images(
                             prompt,
                             num_inference_steps=30,
                             generator=generator,
-                            height=config.dataset.resolution,
-                            width=config.dataset.resolution,
+                            height=config.dataset.image_transforms.resolution,
+                            width=config.dataset.image_transforms.resolution,
                         ).images[0]
                     )
 
@@ -402,9 +402,9 @@ def run_training(config: FinetuneLoRAConfig):  # noqa: C901
     # Prepare VAE output cache.
     vae_output_cache_dir_name = None
     if config.cache_vae_outputs:
-        if config.dataset.random_flip:
+        if config.dataset.image_transforms.random_flip:
             raise ValueError("'cache_vae_outputs' cannot be True if 'random_flip' is True.")
-        if not config.dataset.center_crop:
+        if not config.dataset.image_transforms.center_crop:
             raise ValueError("'cache_vae_outputs' cannot be True if 'center_crop' is False.")
 
         # We use a temporary directory for the cache. The directory will automatically be cleaned up when

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
@@ -26,7 +26,6 @@ from transformers import (
 )
 
 from invoke_training.lora.injection.stable_diffusion import (
-    convert_lora_state_dict_to_kohya_format,
     inject_lora_into_clip_text_encoder,
     inject_lora_into_unet,
 )
@@ -47,8 +46,8 @@ from invoke_training.training.shared.data.data_loaders.image_caption_sdxl_datalo
 from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
     TensorDiskCache,
 )
+from invoke_training.training.shared.lora_checkpoint_utils import save_lora_checkpoint
 from invoke_training.training.shared.optimizer_utils import initialize_optimizer
-from invoke_training.training.shared.serialization import save_state_dict
 
 
 def _import_model_class_for_model(pretrained_model_name_or_path: str, subfolder: str = "", revision: str = "main"):
@@ -148,38 +147,6 @@ def _load_models(
     unet.eval()
 
     return tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet
-
-
-def _save_checkpoint(
-    idx: int,
-    lora_layers: torch.nn.ModuleDict,
-    logger: logging.Logger,
-    checkpoint_tracker: CheckpointTracker,
-):
-    """Save a checkpoint. Old checkpoints are deleted if necessary to respect the config.max_checkpoints config.
-
-    Args:
-        idx (int): The checkpoint index (typically step count or epoch).
-        lora_layers (torch.nn.ModuleDict): The LoRA layers to save in a ModuleDict mapping keys to
-            `LoRALayerCollection`s.
-        logger (logging.Logger): Logger.
-        checkpoint_tracker (CheckpointTracker): The checkpoint tracker.
-    """
-    # Prune checkpoints and get new checkpoint path.
-    num_pruned = checkpoint_tracker.prune(1)
-    if num_pruned > 0:
-        logger.info(f"Pruned {num_pruned} checkpoint(s).")
-    save_path = checkpoint_tracker.get_path(idx)
-
-    state_dict = {}
-    for model_lora_layers in lora_layers.values():
-        model_state_dict = model_lora_layers.get_lora_state_dict()
-        model_kohya_state_dict = convert_lora_state_dict_to_kohya_format(model_state_dict)
-        state_dict.update(model_kohya_state_dict)
-
-    save_state_dict(state_dict, save_path)
-    # accelerator.save_state(save_path)
-    logger.info(f"Saved state to '{save_path}'.")
 
 
 # encode_prompt was adapted from:
@@ -731,7 +698,7 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
                 if config.save_every_n_steps is not None and (global_step + 1) % config.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
-                        _save_checkpoint(global_step + 1, lora_layers, logger, step_checkpoint_tracker)
+                        save_lora_checkpoint(global_step + 1, lora_layers, logger, step_checkpoint_tracker)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -745,7 +712,7 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
         # Save a checkpoint every n epochs.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
             if accelerator.is_main_process:
-                _save_checkpoint(epoch + 1, lora_layers, logger, epoch_checkpoint_tracker)
+                save_lora_checkpoint(epoch + 1, lora_layers, logger, epoch_checkpoint_tracker)
                 accelerator.wait_for_everyone()
 
         # Generate validation images every n epochs.

--- a/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/finetune_lora/finetune_lora_sdxl.py
@@ -331,8 +331,8 @@ def _generate_validation_images(
                             prompt,
                             num_inference_steps=30,
                             generator=generator,
-                            height=config.dataset.resolution,
-                            width=config.dataset.resolution,
+                            height=config.dataset.image_transforms.resolution,
+                            width=config.dataset.image_transforms.resolution,
                         ).images[0]
                     )
 
@@ -420,7 +420,7 @@ def _train_forward(
     # it is a result of the fact that the original size and crop values get concatenated with the time embeddings.
     def compute_time_ids(original_size, crops_coords_top_left):
         # Adapted from pipeline.StableDiffusionXLPipeline._get_add_time_ids
-        target_size = (config.dataset.resolution, config.dataset.resolution)
+        target_size = (config.dataset.image_transforms.resolution, config.dataset.image_transforms.resolution)
         add_time_ids = list(original_size + crops_coords_top_left + target_size)
         add_time_ids = torch.tensor([add_time_ids])
         add_time_ids = add_time_ids.to(accelerator.device, dtype=weight_dtype)
@@ -534,9 +534,9 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
     # Prepare VAE output cache.
     vae_output_cache_dir_name = None
     if config.cache_vae_outputs:
-        if config.dataset.random_flip:
+        if config.dataset.image_transforms.random_flip:
             raise ValueError("'cache_vae_outputs' cannot be True if 'random_flip' is True.")
-        if not config.dataset.center_crop:
+        if not config.dataset.image_transforms.center_crop:
             raise ValueError("'cache_vae_outputs' cannot be True if 'center_crop' is False.")
 
         # We use a temporary directory for the cache. The directory will automatically be cleaned up when

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -80,7 +80,9 @@ def build_image_caption_sd_dataloader(
     if vae_output_cache_dir is None:
         all_transforms.append(
             SDImageTransform(
-                resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip
+                resolution=config.image_transforms.resolution,
+                center_crop=config.image_transforms.center_crop,
+                random_flip=config.image_transforms.random_flip,
             )
         )
     else:

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -3,7 +3,9 @@ import typing
 from torch.utils.data import DataLoader
 from transformers import CLIPTokenizer
 
-from invoke_training.training.config.finetune_lora_config import DatasetConfig
+from invoke_training.training.config.finetune_lora_config import (
+    ImageCaptionDatasetConfig,
+)
 from invoke_training.training.shared.data.datasets.hf_dir_image_caption_dataset import (
     HFDirImageCaptionDataset,
 )
@@ -31,7 +33,7 @@ from invoke_training.training.shared.data.transforms.tensor_disk_cache import (
 
 
 def build_image_caption_sd_dataloader(
-    config: DatasetConfig,
+    config: ImageCaptionDatasetConfig,
     tokenizer: typing.Optional[CLIPTokenizer],
     batch_size: int,
     text_encoder_output_cache_dir: typing.Optional[str] = None,
@@ -41,7 +43,7 @@ def build_image_caption_sd_dataloader(
     """Construct a DataLoader for an image-caption dataset for Stable Diffusion v1/v2..
 
     Args:
-        config (DatasetConfig): The dataset config.
+        config (ImageCaptionDatasetConfig): The dataset config.
         tokenizer (CLIPTokenizer, option): The tokenizer to apply to the captions. Can be None if
             `text_encoder_output_cache_dir` is set.
         batch_size (int): The DataLoader batch size.

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
@@ -110,7 +110,9 @@ def build_image_caption_sdxl_dataloader(
     if vae_output_cache_dir is None:
         all_transforms.append(
             SDXLImageTransform(
-                resolution=config.resolution, center_crop=config.center_crop, random_flip=config.random_flip
+                resolution=config.image_transforms.resolution,
+                center_crop=config.image_transforms.center_crop,
+                random_flip=config.image_transforms.random_flip,
             )
         )
     else:

--- a/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
+++ b/src/invoke_training/training/shared/data/data_loaders/image_caption_sdxl_dataloader.py
@@ -4,7 +4,9 @@ import torch
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizer
 
-from invoke_training.training.config.finetune_lora_config import DatasetConfig
+from invoke_training.training.config.finetune_lora_config import (
+    ImageCaptionDatasetConfig,
+)
 from invoke_training.training.shared.data.datasets.hf_dir_image_caption_dataset import (
     HFDirImageCaptionDataset,
 )
@@ -61,7 +63,7 @@ def _collate_fn(examples):
 
 
 def build_image_caption_sdxl_dataloader(
-    config: DatasetConfig,
+    config: ImageCaptionDatasetConfig,
     tokenizer_1: PreTrainedTokenizer,
     tokenizer_2: PreTrainedTokenizer,
     batch_size: int,
@@ -72,7 +74,7 @@ def build_image_caption_sdxl_dataloader(
     """Construct a DataLoader for an image-caption dataset for Stable Diffusion XL.
 
     Args:
-        config (DatasetConfig): The dataset config.
+        config (ImageCaptionDatasetConfig): The dataset config.
         tokenizer (CLIPTokenizer): The tokenizer to apply to the captions. Can be None if
             `text_encoder_output_cache_dir` is set.
         batch_size (int): The DataLoader batch size.

--- a/src/invoke_training/training/shared/data/datasets/image_dir_dataset.py
+++ b/src/invoke_training/training/shared/data/datasets/image_dir_dataset.py
@@ -1,0 +1,34 @@
+import os
+import typing
+
+import torch.utils.data
+from PIL import Image
+
+
+class ImageDirDataset(torch.utils.data.Dataset):
+    """A dataset that loads image files from a directory."""
+
+    def __init__(self, image_dir: str, image_extensions: typing.Optional[list[str]] = None):
+        """Initialize an ImageDirDataset
+
+        Args:
+            image_dir (str): The directory to load images from.
+            image_extensions (list[str], optional): The list of image file extensions to include in the dataset.
+                Defaults to [".jpg", ".jpeg", ".png"].
+        """
+        super().__init__()
+        if image_extensions is None:
+            image_extensions = [".jpg", ".jpeg", ".png"]
+
+        self._image_paths = []
+
+        for image_file in os.listdir(image_dir):
+            image_path = os.path.join(image_dir, image_file)
+            if os.path.isfile(image_path) and os.path.splitext(image_path)[1] in image_extensions:
+                self._image_paths.append(image_path)
+
+    def __len__(self) -> int:
+        return len(self._image_paths)
+
+    def __getitem__(self, idx: int) -> typing.Dict[str, typing.Any]:
+        return {"id": idx, "image": Image.open(self._image_paths[idx])}

--- a/src/invoke_training/training/shared/lora_checkpoint_utils.py
+++ b/src/invoke_training/training/shared/lora_checkpoint_utils.py
@@ -1,0 +1,41 @@
+import logging
+
+import torch
+
+from invoke_training.lora.injection.stable_diffusion import (
+    convert_lora_state_dict_to_kohya_format,
+)
+from invoke_training.training.shared.checkpoint_tracker import CheckpointTracker
+from invoke_training.training.shared.serialization import save_state_dict
+
+
+def save_lora_checkpoint(
+    idx: int,
+    lora_layers: torch.nn.ModuleDict,
+    logger: logging.Logger,
+    checkpoint_tracker: CheckpointTracker,
+):
+    """Save a LoRA checkpoint. Old checkpoints are deleted if necessary to respect the config.max_checkpoints config.
+
+    Args:
+        idx (int): The checkpoint index (typically step count or epoch).
+        lora_layers (torch.nn.ModuleDict): The LoRA layers to save in a ModuleDict mapping keys to
+            `LoRALayerCollection`s.
+        logger (logging.Logger): Logger.
+        checkpoint_tracker (CheckpointTracker): The checkpoint tracker.
+    """
+    # Prune checkpoints and get new checkpoint path.
+    num_pruned = checkpoint_tracker.prune(1)
+    if num_pruned > 0:
+        logger.info(f"Pruned {num_pruned} checkpoint(s).")
+    save_path = checkpoint_tracker.get_path(idx)
+
+    state_dict = {}
+    for model_lora_layers in lora_layers.values():
+        model_state_dict = model_lora_layers.get_lora_state_dict()
+        model_kohya_state_dict = convert_lora_state_dict_to_kohya_format(model_state_dict)
+        state_dict.update(model_kohya_state_dict)
+
+    save_state_dict(state_dict, save_path)
+    # accelerator.save_state(save_path)
+    logger.info(f"Saved state to '{save_path}'.")

--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
@@ -4,7 +4,9 @@ import pytest
 import torch
 from transformers import CLIPTokenizer
 
-from invoke_training.training.config.finetune_lora_config import DatasetConfig
+from invoke_training.training.config.finetune_lora_config import (
+    ImageCaptionDatasetConfig,
+)
 from invoke_training.training.shared.data.data_loaders.image_caption_sd_dataloader import (
     build_image_caption_sd_dataloader,
 )
@@ -21,7 +23,7 @@ def test_build_image_caption_sd_dataloader():
         revision="c9ab35ff5f2c362e9e22fbafe278077e196057f0",
     )
 
-    config = DatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
+    config = ImageCaptionDatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
     data_loader = build_image_caption_sd_dataloader(config, tokenizer, 4)
 
     # 833 is the length of the dataset determined manually here:

--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
@@ -4,7 +4,9 @@ import pytest
 import torch
 from transformers import CLIPTokenizer
 
-from invoke_training.training.config.finetune_lora_config import DatasetConfig
+from invoke_training.training.config.finetune_lora_config import (
+    ImageCaptionDatasetConfig,
+)
 from invoke_training.training.shared.data.data_loaders.image_caption_sdxl_dataloader import (
     build_image_caption_sdxl_dataloader,
 )
@@ -25,7 +27,7 @@ def test_build_image_caption_sdxl_dataloader():
         local_files_only=True,
     )
 
-    config = DatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
+    config = ImageCaptionDatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
     data_loader = build_image_caption_sdxl_dataloader(config, tokenizer_1, tokenizer_2, 4)
 
     # 833 is the length of the dataset determined manually here:

--- a/tests/invoke_training/training/shared/data/datasets/test_image_dir_dataset.py
+++ b/tests/invoke_training/training/shared/data/datasets/test_image_dir_dataset.py
@@ -1,0 +1,44 @@
+import numpy as np
+import PIL.Image
+import pytest
+
+from invoke_training.training.shared.data.datasets.image_dir_dataset import (
+    ImageDirDataset,
+)
+
+
+@pytest.fixture(scope="session")
+def image_dir(tmp_path_factory: pytest.TempPathFactory):
+    """A fixture that populates a temp directory with some test images and returns the directory path.
+
+    Note that the 'session' scope is used to share the same directory across all tests in a session, because it is
+    costly to populate the directory.
+
+    Refer to https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#the-tmp-path-factory-fixture for details on the use
+    of tmp_path_factory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("dataset")
+
+    for i in range(5):
+        rgb_np = np.ones((128, 128, 3), dtype=np.uint8)
+        rgb_pil = PIL.Image.fromarray(rgb_np)
+        rgb_pil.save(tmp_dir / f"{i}.jpg")
+
+    return tmp_dir
+
+
+def test_image_dir_dataset_len(image_dir):
+    dataset = ImageDirDataset(str(image_dir))
+
+    assert len(dataset) == 5
+
+
+def test_image_dir_dataset_getitem(image_dir):
+    dataset = ImageDirDataset(str(image_dir))
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == 0


### PR DESCRIPTION
This PR contains a number of changes to prepare for DreamBooth support:
- Add `ImageDirDataset` to represent datasets that are simply a directory of images.
- Create DreamBooth script entrypoints (not yet implemented).
- Re-organize Config models to support DreamBooth configs.
- Move duplicate `save_lora_checkpoint(...)` function to a shared location.