### PR TITLE
Fix pydantic validation error in unit tests.

### DIFF
--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sd_dataloader.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from transformers import CLIPTokenizer
 
+from invoke_training.training.config.data_config import ImageTransformConfig
 from invoke_training.training.config.finetune_lora_config import (
     ImageCaptionDatasetConfig,
 )
@@ -23,7 +24,9 @@ def test_build_image_caption_sd_dataloader():
         revision="c9ab35ff5f2c362e9e22fbafe278077e196057f0",
     )
 
-    config = ImageCaptionDatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
+    config = ImageCaptionDatasetConfig(
+        dataset_name="lambdalabs/pokemon-blip-captions", image_transforms=ImageTransformConfig(resolution=512)
+    )
     data_loader = build_image_caption_sd_dataloader(config, tokenizer, 4)
 
     # 833 is the length of the dataset determined manually here:

--- a/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
+++ b/tests/invoke_training/training/shared/data/data_loaders/test_image_caption_sdxl_dataloader.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from transformers import CLIPTokenizer
 
+from invoke_training.training.config.data_config import ImageTransformConfig
 from invoke_training.training.config.finetune_lora_config import (
     ImageCaptionDatasetConfig,
 )
@@ -27,7 +28,9 @@ def test_build_image_caption_sdxl_dataloader():
         local_files_only=True,
     )
 
-    config = ImageCaptionDatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions", resolution=512)
+    config = ImageCaptionDatasetConfig(
+        dataset_name="lambdalabs/pokemon-blip-captions", image_transforms=ImageTransformConfig(resolution=512)
+    )
     data_loader = build_image_caption_sdxl_dataloader(config, tokenizer_1, tokenizer_2, 4)
 
     # 833 is the length of the dataset determined manually here:


### PR DESCRIPTION
Fix a pydantic validation error that was introduced in a recent PR. These tests are only run locally (they have the `loads_model` tag), which is why this wasn't caught in the GitHub action.