### PR TITLE
Add single-file checkpoint loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "datasets~=2.14.3",
     "diffusers~=0.19.3",
     "numpy",
+    "omegaconf",
     "Pillow",
     "prodigyopt",
     "pydantic",

--- a/src/invoke_training/scripts/invoke_generate_images.py
+++ b/src/invoke_training/scripts/invoke_generate_images.py
@@ -1,5 +1,6 @@
 import argparse
 
+from invoke_training.training.shared.model_loading_utils import PipelineVersionEnum
 from invoke_training.training.tools.generate_images import generate_images
 
 
@@ -26,7 +27,7 @@ def parse_args():
         "--sd-version",
         type=str,
         required=True,
-        help="The Stable Diffusion version. One of: ['sd', 'sdxl'].",
+        help="The Stable Diffusion version. One of: ['SD', 'SDXL'].",
     )
     parser.add_argument("--prompt", type=str, required=True, help="The prompt to use for image generation.")
     parser.add_argument(
@@ -69,7 +70,7 @@ def main():
     generate_images(
         out_dir=args.out_dir,
         model=args.model,
-        sd_version=args.sd_version,
+        pipeline_version=PipelineVersionEnum(args.sd_version),
         prompt=args.prompt,
         num_images=args.num_images,
         height=args.height,

--- a/src/invoke_training/scripts/invoke_generate_images.py
+++ b/src/invoke_training/scripts/invoke_generate_images.py
@@ -18,8 +18,15 @@ def parse_args():
         "--model",
         type=str,
         required=True,
-        help="Name or path of the diffusers model to generate images with. (E.g. 'runwayml/stable-diffusion-v1-5', "
-        "'stabilityai/stable-diffusion-xl-base-1.0', etc. )",
+        help="Name or path of the diffusers model to generate images with. Can be in diffusers format, or a single "
+        "stable diffusion checkpoint file. (E.g. 'runwayml/stable-diffusion-v1-5', "
+        "'stabilityai/stable-diffusion-xl-base-1.0', '/path/to/realisticVisionV51_v51VAE.safetensors', etc. )",
+    )
+    parser.add_argument(
+        "--sd-version",
+        type=str,
+        required=True,
+        help="The Stable Diffusion version. One of: ['sd', 'sdxl'].",
     )
     parser.add_argument("--prompt", type=str, required=True, help="The prompt to use for image generation.")
     parser.add_argument(
@@ -58,10 +65,11 @@ def parse_args():
 def main():
     args = parse_args()
 
-    print(f"Generating {args.num_images} at '{args.out_dir}'.")
+    print(f"Generating {args.num_images} images in '{args.out_dir}'.")
     generate_images(
         out_dir=args.out_dir,
         model=args.model,
+        sd_version=args.sd_version,
         prompt=args.prompt,
         num_images=args.num_images,
         height=args.height,

--- a/src/invoke_training/training/config/finetune_lora_config.py
+++ b/src/invoke_training/training/config/finetune_lora_config.py
@@ -31,7 +31,9 @@ class TrainingOutputConfig(BaseModel):
 class LoRATrainingConfig(BaseModel):
     """The base configuration for any LoRA training run."""
 
-    # The name of the Hugging Face Hub model to train against.
+    # Name or path of the base model to train. Can be in diffusers format, or a single stable diffusion checkpoint file.
+    # (E.g. 'runwayml/stable-diffusion-v1-5', 'stabilityai/stable-diffusion-xl-base-1.0',
+    # '/path/to/realisticVisionV51_v51VAE.safetensors', etc. )
     model: str = "runwayml/stable-diffusion-v1-5"
 
     # A seed for reproducible training.

--- a/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sd.py
+++ b/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sd.py
@@ -25,10 +25,6 @@ from invoke_training.training.shared.accelerator_utils import (
     initialize_accelerator,
     initialize_logging,
 )
-from invoke_training.training.shared.base_model_version import (
-    BaseModelVersionEnum,
-    check_base_model_version,
-)
 from invoke_training.training.shared.checkpoint_tracker import CheckpointTracker
 from invoke_training.training.shared.data.data_loaders.dreambooth_sd_dataloader import (
     build_dreambooth_sd_dataloader,
@@ -39,11 +35,12 @@ from invoke_training.training.shared.optimizer_utils import initialize_optimizer
 
 def run_training(config: DreamBoothLoRAConfig):  # noqa: C901
     # Give a clear error message if an unsupported base model was chosen.
-    check_base_model_version(
-        {BaseModelVersionEnum.STABLE_DIFFUSION_V1, BaseModelVersionEnum.STABLE_DIFFUSION_V2},
-        config.model,
-        local_files_only=False,
-    )
+    # TODO(ryan): Update this check to work with single-file SD checkpoints.
+    # check_base_model_version(
+    #     {BaseModelVersionEnum.STABLE_DIFFUSION_V1, BaseModelVersionEnum.STABLE_DIFFUSION_V2},
+    #     config.model,
+    #     local_files_only=False,
+    # )
 
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")

--- a/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sdxl.py
+++ b/src/invoke_training/training/dreambooth_lora/dreambooth_lora_sdxl.py
@@ -27,10 +27,6 @@ from invoke_training.training.shared.accelerator_utils import (
     initialize_accelerator,
     initialize_logging,
 )
-from invoke_training.training.shared.base_model_version import (
-    BaseModelVersionEnum,
-    check_base_model_version,
-)
 from invoke_training.training.shared.checkpoint_tracker import CheckpointTracker
 from invoke_training.training.shared.data.data_loaders.dreambooth_sdxl_dataloader import (
     build_dreambooth_sdxl_dataloader,
@@ -41,11 +37,12 @@ from invoke_training.training.shared.optimizer_utils import initialize_optimizer
 
 def run_training(config: DreamBoothLoRASDXLConfig):  # noqa: C901
     # Give a clear error message if an unsupported base model was chosen.
-    check_base_model_version(
-        {BaseModelVersionEnum.STABLE_DIFFUSION_SDXL_BASE},
-        config.model,
-        local_files_only=False,
-    )
+    # TODO(ryan): Update this check to work with single-file SD checkpoints.
+    # check_base_model_version(
+    #     {BaseModelVersionEnum.STABLE_DIFFUSION_SDXL_BASE},
+    #     config.model,
+    #     local_files_only=False,
+    # )
 
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")

--- a/src/invoke_training/training/shared/model_loading_utils.py
+++ b/src/invoke_training/training/shared/model_loading_utils.py
@@ -1,0 +1,41 @@
+import os
+import typing
+from enum import Enum
+
+from diffusers import StableDiffusionPipeline, StableDiffusionXLPipeline
+
+
+class PipelineVersionEnum(Enum):
+    SD = "SD"
+    SDXL = "SDXL"
+
+
+def load_pipeline(
+    model_name_or_path: str, pipeline_version: PipelineVersionEnum
+) -> typing.Union[StableDiffusionPipeline, StableDiffusionXLPipeline]:
+    """Load a Stable Diffusion pipeline from disk.
+
+    Args:
+        model_name_or_path (str): The name or path of the pipeline to load. Can be in diffusers format, or a single
+            stable diffusion checkpoint file. (E.g. 'runwayml/stable-diffusion-v1-5',
+            'stabilityai/stable-diffusion-xl-base-1.0', '/path/to/realisticVisionV51_v51VAE.safetensors', etc. )
+        pipeline_version (PipelineVersionEnum): The pipeline version.
+
+    Returns:
+        typing.Union[StableDiffusionPipeline, StableDiffusionXLPipeline]: The loaded pipeline.
+    """
+    if pipeline_version == PipelineVersionEnum.SD:
+        pipeline_class = StableDiffusionPipeline
+    elif pipeline_version == PipelineVersionEnum.SDXL:
+        pipeline_class = StableDiffusionXLPipeline
+    else:
+        raise ValueError(f"Unsupported pipeline_version: '{pipeline_version}'.")
+
+    if os.path.isfile(model_name_or_path):
+        return pipeline_class.from_single_file(model_name_or_path, load_safety_checker=False)
+
+    return pipeline_class.from_pretrained(
+        model_name_or_path,
+        safety_checker=None,
+        requires_safety_checker=False,
+    )

--- a/src/invoke_training/training/tools/generate_images.py
+++ b/src/invoke_training/training/tools/generate_images.py
@@ -1,13 +1,19 @@
 import os
+import typing
 
 import torch
-from diffusers import DiffusionPipeline
+from diffusers import (
+    DiffusionPipeline,
+    StableDiffusionPipeline,
+    StableDiffusionXLPipeline,
+)
 from tqdm import tqdm
 
 
 def generate_images(
     out_dir: str,
     model: str,
+    sd_version: typing.Literal["sd", "sdxl"],
     prompt: str,
     num_images: int,
     height: int,
@@ -23,6 +29,7 @@ def generate_images(
     Args:
         out_dir (str): The output directory to create.
         model (str): The name or path of the diffusers pipeline to generate with.
+        sd_version (str): The model version. One of: ["sd", "sdxl"].
         prompt (str): The prompt to generate images with.
         num_images (int): The number of images to generate.
         height (int): The output image height in pixels (recommended to match the resolution that the model was trained
@@ -35,11 +42,22 @@ def generate_images(
         enable_cpu_offload (bool, optional): If True, models will be loaded onto the GPU one by one to conserve VRAM.
             Defaults to False.
     """
-    pipeline = DiffusionPipeline.from_pretrained(
-        model,
-        safety_checker=None,
-        requires_safety_checker=False,
-    )
+
+    if sd_version == "sd":
+        pipeline_class = StableDiffusionPipeline
+    elif sd_version == "sdxl":
+        pipeline_class = StableDiffusionXLPipeline
+    else:
+        raise ValueError(f"Unsupported sd_version: '{sd_version}'.")
+
+    if os.path.isfile(model):
+        pipeline = pipeline_class.from_single_file(model, load_safety_checker=False)
+    else:
+        pipeline = DiffusionPipeline.from_pretrained(
+            model,
+            safety_checker=None,
+            requires_safety_checker=False,
+        )
 
     pipeline.to(torch_dtype=torch_dtype)
     if enable_cpu_offload:


### PR DESCRIPTION
Add the ability to load single-file base models. This enables users to train from popular finetuned models (e.g. realisticVision).