### PR TITLE
Add ruff-lsp dependency for ruff support in non-VSCode editors.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pytest~=7.4.0",
     # When bumping ruff, consider also bumping the ruff-pre-commit version in .pre-commit-config.yaml.
     "ruff~=0.1.7",
+    "ruff-lsp",
 ]
 
 [project.scripts]


### PR DESCRIPTION
@psychedelicious This PR was motivated by this comment: https://github.com/invoke-ai/invoke-training/pull/39#discussion_r1419798501