### PR TITLE
Fix SDXL TI sample config

### DIFF
--- a/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
+++ b/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
@@ -31,6 +31,7 @@ data_loader:
 
 # General
 model: stabilityai/stable-diffusion-xl-base-1.0
+vae_model: madebyollin/sdxl-vae-fp16-fix
 num_vectors: 1
 placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"


### PR DESCRIPTION
Switch to using the [`madebyollin/sdxl-vae-fp16-fix`](https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) VAE for SDXL TI training in fp16 mode. Without this fixed version, training produces black images. This seems to have been removed by accident in a previous commit.