### PR TITLE
Forbid extra config fields

### DIFF
--- a/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
+++ b/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
@@ -44,7 +44,6 @@ max_train_steps: 2000
 save_every_n_epochs: 50
 save_every_n_steps: null
 max_checkpoints: 200
-validation_resolution: 512
 validation_prompts:
   - A photo of bruce_the_gnome at the beach
   - A photo of bruce_the_gnome reading a book

--- a/src/invoke_training/config/_experimental/dpo/config.py
+++ b/src/invoke_training/config/_experimental/dpo/config.py
@@ -1,26 +1,27 @@
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from invoke_training.config.pipelines.finetune_lora_config import LoRATrainingConfig
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 from invoke_training.config.shared.data.transform_config import SDImageTransformConfig
 from invoke_training.config.shared.optimizer.optimizer_config import OptimizerConfig
 
 
-class HFHubImagePairPreferenceDatasetConfig(BaseModel):
+class HFHubImagePairPreferenceDatasetConfig(ConfigBaseModel):
     type: Literal["HF_HUB_IMAGE_PAIR_PREFERENCE_DATASET"] = "HF_HUB_IMAGE_PAIR_PREFERENCE_DATASET"
 
     # TODO(ryand): Fill this out.
 
 
-class ImagePairPreferenceDatasetConfig(BaseModel):
+class ImagePairPreferenceDatasetConfig(ConfigBaseModel):
     type: Literal["IMAGE_PAIR_PREFERENCE_DATASET"] = "IMAGE_PAIR_PREFERENCE_DATASET"
 
     dataset_dir: str
     """The directory to load the dataset from."""
 
 
-class ImagePairPreferenceSDDataLoaderConfig(BaseModel):
+class ImagePairPreferenceSDDataLoaderConfig(ConfigBaseModel):
     type: Literal["IMAGE_PAIR_PREFERENCE_SD_DATA_LOADER"] = "IMAGE_PAIR_PREFERENCE_SD_DATA_LOADER"
 
     dataset: Annotated[

--- a/src/invoke_training/config/pipelines/base_pipeline_config.py
+++ b/src/invoke_training/config/pipelines/base_pipeline_config.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-from pydantic import BaseModel
-
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 from invoke_training.config.shared.training_output_config import TrainingOutputConfig
 
 
-class BasePipelineConfig(BaseModel):
+class BasePipelineConfig(ConfigBaseModel):
     """A base config with fields that should be inherited by all pipelines."""
 
     type: str

--- a/src/invoke_training/config/shared/config_base_model.py
+++ b/src/invoke_training/config/shared/config_base_model.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class ConfigBaseModel(BaseModel):
+    """Base model for all invoke training configuration models."""
+
+    # Configure to raise if extra fields are passed in.
+    model_config = ConfigDict(extra="forbid")

--- a/src/invoke_training/config/shared/data/data_loader_config.py
+++ b/src/invoke_training/config/shared/data/data_loader_config.py
@@ -1,7 +1,6 @@
 from typing import Literal, Optional
 
-from pydantic import BaseModel
-
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 from invoke_training.config.shared.data.dataset_config import (
     ImageCaptionDatasetConfig,
     ImageDirDatasetConfig,
@@ -13,7 +12,7 @@ from invoke_training.config.shared.data.transform_config import (
 )
 
 
-class AspectRatioBucketConfig(BaseModel):
+class AspectRatioBucketConfig(ConfigBaseModel):
     target_resolution: int
     """The target resolution for all aspect ratios. When generating aspect ratio buckets, the resolution of each bucket
     is selected to have roughly `target_resolution * target_resolution` pixels (i.e. a square image with dimensions
@@ -45,7 +44,7 @@ class AspectRatioBucketConfig(BaseModel):
     """
 
 
-class ImageCaptionSDDataLoaderConfig(BaseModel):
+class ImageCaptionSDDataLoaderConfig(ConfigBaseModel):
     type: Literal["IMAGE_CAPTION_SD_DATA_LOADER"] = "IMAGE_CAPTION_SD_DATA_LOADER"
 
     dataset: ImageCaptionDatasetConfig
@@ -59,7 +58,7 @@ class ImageCaptionSDDataLoaderConfig(BaseModel):
     """
 
 
-class DreamboothSDDataLoaderConfig(BaseModel):
+class DreamboothSDDataLoaderConfig(ConfigBaseModel):
     type: Literal["DREAMBOOTH_SD_DATA_LOADER"] = "DREAMBOOTH_SD_DATA_LOADER"
 
     instance_caption: str
@@ -84,7 +83,7 @@ class DreamboothSDDataLoaderConfig(BaseModel):
     """
 
 
-class TextualInversionSDDataLoaderConfig(BaseModel):
+class TextualInversionSDDataLoaderConfig(ConfigBaseModel):
     type: Literal["TEXTUAL_INVERSION_SD_DATA_LOADER"] = "TEXTUAL_INVERSION_SD_DATA_LOADER"
 
     dataset: ImageDirDatasetConfig

--- a/src/invoke_training/config/shared/data/dataset_config.py
+++ b/src/invoke_training/config/shared/data/dataset_config.py
@@ -1,9 +1,11 @@
 from typing import Annotated, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 
 
-class HFHubImageCaptionDatasetConfig(BaseModel):
+class HFHubImageCaptionDatasetConfig(ConfigBaseModel):
     type: Literal["HF_HUB_IMAGE_CAPTION_DATASET"] = "HF_HUB_IMAGE_CAPTION_DATASET"
 
     dataset_name: str
@@ -28,7 +30,7 @@ class HFHubImageCaptionDatasetConfig(BaseModel):
     """
 
 
-class HFDirImageCaptionDatasetConfig(BaseModel):
+class HFDirImageCaptionDatasetConfig(ConfigBaseModel):
     type: Literal["HF_DIR_IMAGE_CAPTION_DATASET"] = "HF_DIR_IMAGE_CAPTION_DATASET"
 
     dataset_dir: str
@@ -44,7 +46,7 @@ class HFDirImageCaptionDatasetConfig(BaseModel):
     """
 
 
-class ImageDirDatasetConfig(BaseModel):
+class ImageDirDatasetConfig(ConfigBaseModel):
     type: Literal["IMAGE_DIR_DATASET"] = "IMAGE_DIR_DATASET"
 
     dataset_dir: str

--- a/src/invoke_training/config/shared/data/transform_config.py
+++ b/src/invoke_training/config/shared/data/transform_config.py
@@ -1,9 +1,11 @@
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 
 
-class SDImageTransformConfig(BaseModel):
+class SDImageTransformConfig(ConfigBaseModel):
     resolution: int = 512
     """The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
     """
@@ -18,7 +20,7 @@ class SDImageTransformConfig(BaseModel):
     """
 
 
-class TextualInversionCaptionTransformConfig(BaseModel):
+class TextualInversionCaptionTransformConfig(ConfigBaseModel):
     type: Literal["TEXTUAL_INVERSION_CAPTION_TRANSFORM"] = "TEXTUAL_INVERSION_CAPTION_TRANSFORM"
 
     templates: list[str]
@@ -30,7 +32,7 @@ class TextualInversionCaptionTransformConfig(BaseModel):
     """
 
 
-class TextualInversionPresetCaptionTransformConfig(BaseModel):
+class TextualInversionPresetCaptionTransformConfig(ConfigBaseModel):
     type: Literal["TEXTUAL_INVERSION_PRESET_CAPTION_TRANSFORM"] = "TEXTUAL_INVERSION_PRESET_CAPTION_TRANSFORM"
 
     preset: Literal["style", "object"]
@@ -45,6 +47,6 @@ TextualInversionCaptionConfig = Annotated[
 ]
 
 
-class ShuffleCaptionTransformConfig(BaseModel):
+class ShuffleCaptionTransformConfig(ConfigBaseModel):
     delimiter: str = ","
     """The delimiter to use for caption splitting."""

--- a/src/invoke_training/config/shared/optimizer/optimizer_config.py
+++ b/src/invoke_training/config/shared/optimizer/optimizer_config.py
@@ -1,9 +1,9 @@
 import typing
 
-from pydantic import BaseModel
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 
 
-class AdamOptimizer(BaseModel):
+class AdamOptimizer(ConfigBaseModel):
     optimizer_type: typing.Literal["AdamW"] = "AdamW"
 
     beta1: float = 0.9
@@ -12,7 +12,7 @@ class AdamOptimizer(BaseModel):
     epsilon: float = 1e-8
 
 
-class ProdigyOptimizer(BaseModel):
+class ProdigyOptimizer(ConfigBaseModel):
     optimizer_type: typing.Literal["Prodigy"] = "Prodigy"
 
     weight_decay: float = 0.0
@@ -20,7 +20,7 @@ class ProdigyOptimizer(BaseModel):
     safeguard_warmup: bool = False
 
 
-class OptimizerConfig(BaseModel):
+class OptimizerConfig(ConfigBaseModel):
     """Configuration for a training optimizer."""
 
     optimizer: typing.Union[AdamOptimizer, ProdigyOptimizer] = AdamOptimizer()

--- a/src/invoke_training/config/shared/training_output_config.py
+++ b/src/invoke_training/config/shared/training_output_config.py
@@ -1,9 +1,9 @@
 import typing
 
-from pydantic import BaseModel
+from invoke_training.config.shared.config_base_model import ConfigBaseModel
 
 
-class TrainingOutputConfig(BaseModel):
+class TrainingOutputConfig(ConfigBaseModel):
     """Configuration for a training run's output."""
 
     base_output_dir: str

--- a/tests/invoke_training/config/pipelines/test_pipeline_config.py
+++ b/tests/invoke_training/config/pipelines/test_pipeline_config.py
@@ -1,0 +1,27 @@
+import glob
+from pathlib import Path
+
+import yaml
+from pydantic import TypeAdapter
+
+from invoke_training.config.pipelines.pipeline_config import PipelineConfig
+
+
+def test_pipeline_config():
+    """Test that all sample pipeline configs can be parse as PipelineConfigs."""
+    cur_file = Path(__file__)
+    config_dir = cur_file.parent.parent.parent.parent.parent / "configs"
+    config_files = glob.glob(str(config_dir) + "/**/*.yaml", recursive=True)
+
+    assert len(config_files) > 0
+
+    for config_file in config_files:
+        with open(config_file, "r") as f:
+            cfg = yaml.safe_load(f)
+
+        pipeline_adapter: TypeAdapter[PipelineConfig] = TypeAdapter(PipelineConfig)
+
+        try:
+            _ = pipeline_adapter.validate_python(cfg)
+        except Exception as e:
+            raise Exception(f"Error parsing config file: {config_file}") from e


### PR DESCRIPTION
- Configure the configuration Pydantic models to forbid extra config fields.
- Fix one instance of an extra field in one of the sample cofigs.
- Add a unit test that validates that all configs in the `configs/` directory can be loaded and parse successfully.