### PR TITLE
Add a keep_in_memory option to ImageDirDataset

### DIFF
--- a/configs/textual_inversion_sd_gnome_1x8gb_example.yaml
+++ b/configs/textual_inversion_sd_gnome_1x8gb_example.yaml
@@ -20,6 +20,7 @@ data_loader:
   dataset:
     type: IMAGE_DIR_DATASET
     dataset_dir: "sample_data/bruce_the_gnome"
+    keep_in_memory: True
   captions:
     type: TEXTUAL_INVERSION_PRESET_CAPTION_TRANSFORM
     preset: object

--- a/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
+++ b/configs/textual_inversion_sdxl_gnome_1x24gb_example.yaml
@@ -20,6 +20,7 @@ data_loader:
   dataset:
     type: IMAGE_DIR_DATASET
     dataset_dir: "sample_data/bruce_the_gnome"
+    keep_in_memory: True
   captions:
     type: TEXTUAL_INVERSION_PRESET_CAPTION_TRANSFORM
     preset: object

--- a/src/invoke_training/config/shared/data/dataset_config.py
+++ b/src/invoke_training/config/shared/data/dataset_config.py
@@ -52,6 +52,12 @@ class ImageDirDatasetConfig(ConfigBaseModel):
     dataset_dir: str
     """The directory to load images from."""
 
+    keep_in_memory: bool = False
+    """If `True`, load all images into memory on initialization so that they can be accessed quickly. If `False`, images
+    are loaded from disk each time they are accessed. Setting to `True` improves performance for datasets that are small
+    enough to be kept in memory.
+    """
+
 
 # Datasets that produce image-caption pairs.
 ImageCaptionDatasetConfig = Annotated[

--- a/src/invoke_training/training/_shared/data/data_loaders/dreambooth_sd_dataloader.py
+++ b/src/invoke_training/training/_shared/data/data_loaders/dreambooth_sd_dataloader.py
@@ -53,7 +53,11 @@ def build_dreambooth_sd_dataloader(
         DataLoader
     """
     # Prepare instance dataset.
-    base_instance_dataset = ImageDirDataset(config.instance_dataset.dataset_dir, id_prefix="instance_")
+    base_instance_dataset = ImageDirDataset(
+        config.instance_dataset.dataset_dir,
+        id_prefix="instance_",
+        keep_in_memory=config.instance_dataset.keep_in_memory,
+    )
     instance_dataset = TransformDataset(
         base_instance_dataset,
         [
@@ -67,7 +71,9 @@ def build_dreambooth_sd_dataloader(
     base_class_dataset = None
     class_dataset = None
     if config.class_dataset is not None:
-        base_class_dataset = ImageDirDataset(config.class_dataset.dataset_dir, id_prefix="class_")
+        base_class_dataset = ImageDirDataset(
+            config.class_dataset.dataset_dir, id_prefix="class_", keep_in_memory=config.class_dataset.keep_in_memory
+        )
         class_dataset = TransformDataset(
             base_class_dataset,
             [

--- a/src/invoke_training/training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
+++ b/src/invoke_training/training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
@@ -104,7 +104,7 @@ def build_textual_inversion_sd_dataloader(
     """
     placeholder_str = " ".join(placeholder_tokens)
 
-    base_dataset = ImageDirDataset(image_dir=config.dataset.dataset_dir)
+    base_dataset = ImageDirDataset(image_dir=config.dataset.dataset_dir, keep_in_memory=config.dataset.keep_in_memory)
 
     if isinstance(config.captions, TextualInversionCaptionTransformConfig):
         caption_templates = config.captions.templates

--- a/tests/invoke_training/training/_shared/data/datasets/test_image_dir_dataset.py
+++ b/tests/invoke_training/training/_shared/data/datasets/test_image_dir_dataset.py
@@ -22,6 +22,17 @@ def test_image_dir_dataset_getitem(image_dir):  # noqa: F811
     assert example["id"] == "0"
 
 
+def test_image_dir_dataset_keep_in_memory(image_dir):  # noqa: F811
+    dataset = ImageDirDataset(str(image_dir), keep_in_memory=True)
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == "0"
+
+
 def test_image_dir_dataset_get_image_dimensions(image_dir):  # noqa: F811
     dataset = ImageDirDataset(str(image_dir))
 


### PR DESCRIPTION
`keep_in_memory = True` improves speed for datasets that are small enough to be held in memory.