### PR TITLE
TI initial_phrase, and other misc. improvements

### DIFF
--- a/src/invoke_training/config/pipelines/textual_inversion_config.py
+++ b/src/invoke_training/config/pipelines/textual_inversion_config.py
@@ -24,10 +24,15 @@ class TextualInversionTrainingConfig(BasePipelineConfig):
     # Helpful discussion for understanding how this works at inference time:
     # https://github.com/huggingface/diffusers/pull/3144#discussion_r1172413509
     num_vectors: int = 1
-    """The number of textual inversion placeholder vectors that will be used to learn the concept.
+    """Note: `num_vectors` can be overridden by `initial_phrase`.
 
-    Increasing the `num_vectors` enables the model to learn more complex concepts, but increases the risk of overfitting
-    and increases the size of the resulting output file.
+    The number of textual inversion embedding vectors that will be used to learn the concept.
+
+    Increasing the `num_vectors` enables the model to learn more complex concepts, but has the following drawbacks:
+
+    - greater risk of overfitting
+    - increased size of the resulting output file
+    - consumes more of the prompt capacity at inference time
 
     Typical values for `num_vectors` are in the range [1, 16].
 
@@ -40,17 +45,32 @@ class TextualInversionTrainingConfig(BasePipelineConfig):
     """
 
     initializer_token: Optional[str] = None
-    """A vocabulary token to use as an initializer for the placeholder token. It should be a single word that roughly
+    """Note: Exactly one of `initializer_token`, `initial_embedding_file`, or `initial_phrase` should be set.
+
+    A vocabulary token to use as an initializer for the placeholder token. It should be a single word that roughly
     describes the object or style that you're trying to train on. Must map to a single tokenizer token.
+
+    For example, if you are training on a dataset of images of your pet dog, a good choice would be `dog`.
+    """
+
+    initial_embedding_file: Optional[str] = None
+    """Note: Exactly one of `initializer_token`, `initial_embedding_file`, or `initial_phrase` should be set.
+
+    Path to an existing TI embedding that will be used to initialize the embedding being trained. The placeholder
+    token in the file must match the `placeholder_token` field.
 
     Either `initializer_token` or `initial_embedding_file` should be set.
     """
 
-    initial_embedding_file: Optional[str] = None
-    """Path to an existing TI embedding that will be used to initialize the embedding being trained. The placeholder
-    token in the file must match the `placeholder_token` field.
+    initial_phrase: Optional[str] = None
+    """Note: Exactly one of `initializer_token`, `initial_embedding_file`, or `initial_phrase` should be set.
 
-    Either `initializer_token` or `initial_embedding_file` should be set.
+    A phrase that will be used to initialize the placeholder token embedding. The phrase will be tokenized, and the
+    corresponding embeddings will be used to initialize the placeholder tokens. The number of embedding vectors will be
+    inferred from the length of the tokenized phrase, so keep the phrase short. The consequences of training a large
+    number of embedding vectors are discussed in the `num_vectors` field documentation.
+
+    For example, if you are training on a dataset of images of pokemon, you might use `pokemon sketch white background`.
     """
 
     cache_vae_outputs: bool = False

--- a/src/invoke_training/config/shared/data/data_loader_config.py
+++ b/src/invoke_training/config/shared/data/data_loader_config.py
@@ -86,9 +86,15 @@ class DreamboothSDDataLoaderConfig(ConfigBaseModel):
 class TextualInversionSDDataLoaderConfig(ConfigBaseModel):
     type: Literal["TEXTUAL_INVERSION_SD_DATA_LOADER"] = "TEXTUAL_INVERSION_SD_DATA_LOADER"
 
-    dataset: ImageDirDatasetConfig
+    dataset: ImageDirDatasetConfig | ImageCaptionDatasetConfig
 
     captions: TextualInversionCaptionConfig
+    """The caption configuration. One of:
+
+    - [`TextualInversionPresetCaptionTransformConfig`][invoke_training.config.shared.data.transform_config.TextualInversionPresetCaptionTransformConfig]: Use preset `object` or `style` caption templates.
+    - [`TextualInversionCaptionTransformConfig`][invoke_training.config.shared.data.transform_config.TextualInversionCaptionTransformConfig]: Use custom caption templates.
+    - [`TextualInversionCaptionPrefixTransformConfig`][invoke_training.config.shared.data.transform_config.TextualInversionCaptionPrefixTransformConfig]: Prepend the textual inversion token(s) to all existing dataset captions.
+    """  # noqa: E501
 
     image_transforms: SDImageTransformConfig
     """The image transforms to apply to all images.

--- a/src/invoke_training/config/shared/data/transform_config.py
+++ b/src/invoke_training/config/shared/data/transform_config.py
@@ -27,6 +27,7 @@ class TextualInversionCaptionTransformConfig(ConfigBaseModel):
     templates: list[str]
     """A list of caption templates with a single template argument 'slot' in each.
     E.g.:
+
     - "a photo of a {}"
     - "a rendering of a {}"
     - "a cropped photo of the {}"
@@ -39,10 +40,15 @@ class TextualInversionPresetCaptionTransformConfig(ConfigBaseModel):
     preset: Literal["style", "object"]
 
 
+class TextualInversionCaptionPrefixTransformConfig(ConfigBaseModel):
+    type: Literal["TEXTUAL_INVERSION_CAPTION_PREFIX_TRANSFORM"] = "TEXTUAL_INVERSION_CAPTION_PREFIX_TRANSFORM"
+
+
 TextualInversionCaptionConfig = Annotated[
     Union[
         TextualInversionCaptionTransformConfig,
         TextualInversionPresetCaptionTransformConfig,
+        TextualInversionCaptionPrefixTransformConfig,
     ],
     Field(discriminator="type"),
 ]

--- a/src/invoke_training/config/shared/data/transform_config.py
+++ b/src/invoke_training/config/shared/data/transform_config.py
@@ -6,8 +6,9 @@ from invoke_training.config.shared.config_base_model import ConfigBaseModel
 
 
 class SDImageTransformConfig(ConfigBaseModel):
-    resolution: int = 512
-    """The resolution for input images. All of the images in the dataset will be resized to this (square) resolution.
+    resolution: int | tuple[int, int] = 512
+    """The resolution for input images. Either a scalar integer representing the square resolution height and width, or
+    a (height, width) tuple. All of the images in the dataset will be resized to this resolution.
     """
 
     center_crop: bool = True

--- a/src/invoke_training/scripts/invoke_visualize_data_loading.py
+++ b/src/invoke_training/scripts/invoke_visualize_data_loading.py
@@ -21,7 +21,6 @@ from invoke_training.training._shared.data.data_loaders.image_pair_preference_sd
 from invoke_training.training._shared.data.data_loaders.textual_inversion_sd_dataloader import (
     build_textual_inversion_sd_dataloader,
 )
-from invoke_training.training._shared.stable_diffusion.textual_inversion import expand_placeholder_token
 
 
 def save_image(torch_image: torch.Tensor, out_path: Path):
@@ -106,10 +105,9 @@ def main():
             shuffle=False,
         )
     elif data_loader_config.type == "TEXTUAL_INVERSION_SD_DATA_LOADER":
-        placeholder_tokens = expand_placeholder_token(train_config.placeholder_token, train_config.num_vectors)
         data_loader = build_textual_inversion_sd_dataloader(
             config=data_loader_config,
-            placeholder_tokens=placeholder_tokens,
+            placeholder_tokens=["<placeholder_tokens_are_not_shown_when_visualizing>"],
             batch_size=train_config.train_batch_size,
             shuffle=False,
         )

--- a/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
+++ b/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
@@ -188,7 +188,8 @@ def run_training(config: DirectPreferenceOptimizationLoRASDConfig):  # noqa: C90
 
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")
-    os.makedirs(out_dir)
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+    os.makedirs(ckpt_dir)
 
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.output.report_to
@@ -423,14 +424,14 @@ def run_training(config: DirectPreferenceOptimizationLoRASDConfig):  # noqa: C90
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
     epoch_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_step",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,

--- a/src/invoke_training/training/_shared/data/samplers/aspect_ratio_bucket_batch_sampler.py
+++ b/src/invoke_training/training/_shared/data/samplers/aspect_ratio_bucket_batch_sampler.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import math
 import random
 from typing import Iterator
@@ -29,6 +30,15 @@ class AspectRatioBucketBatchSampler(Sampler[list[int]]):
         self._batch_size = batch_size
         self._shuffle = shuffle
         self._random = random.Random(seed)
+
+    def __str__(self) -> str:
+        buckets = self.get_buckets()
+        bucket_resolutions = sorted(list(buckets.keys()))
+        s = ""
+        for bucket_resolution in bucket_resolutions:
+            bucket_images = buckets[bucket_resolution]
+            s += f"  {bucket_resolution.to_tuple()}: {len(bucket_images)}\n"
+        return s
 
     @classmethod
     def from_image_sizes(
@@ -95,3 +105,13 @@ class AspectRatioBucketBatchSampler(Sampler[list[int]]):
         for bucket_images in self._buckets.values():
             num_batches += math.ceil(len(bucket_images) / self._batch_size)
         return num_batches
+
+
+def log_aspect_ratio_buckets(logger: logging.Logger, batch_sampler: AspectRatioBucketBatchSampler):
+    """Utility function for logging the aspect ratio buckets."""
+    if not isinstance(batch_sampler, AspectRatioBucketBatchSampler):
+        return
+
+    log = "Aspect Ratio Buckets:\n"
+    log += str(batch_sampler)
+    logger.info(log)

--- a/src/invoke_training/training/_shared/data/transforms/caption_prefix_transform.py
+++ b/src/invoke_training/training/_shared/data/transforms/caption_prefix_transform.py
@@ -1,0 +1,13 @@
+import typing
+
+
+class CaptionPrefixTransform:
+    """A transform that adds a prefix to all example captions."""
+
+    def __init__(self, caption_field_name: str, prefix: str):
+        self._caption_field_name = caption_field_name
+        self._prefix = prefix
+
+    def __call__(self, data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        data[self._caption_field_name] = self._prefix + data[self._caption_field_name]
+        return data

--- a/src/invoke_training/training/_shared/data/transforms/template_caption_transform.py
+++ b/src/invoke_training/training/_shared/data/transforms/template_caption_transform.py
@@ -3,7 +3,7 @@ import typing
 import numpy as np
 
 
-class TextualInversionCaptionTransform:
+class TemplateCaptionTransform:
     """A simple transform that constructs a caption for each example by combining a caption template with the
     placeholder string.
     """

--- a/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
@@ -47,6 +47,16 @@ def save_multi_model_peft_checkpoint(checkpoint_dir: Path | str, models: dict[st
     checkpoint_dir = Path(checkpoint_dir)
     for model_key, peft_model in models.items():
         assert isinstance(peft_model, peft.PeftModel)
+
+        # HACK(ryand): PeftModel.save_pretrained(...) expects the config to have a "_name_or_path" entry. For now, we
+        # set this to None here. This should be fixed upstream in PEFT.
+        if (
+            hasattr(peft_model, "config")
+            and isinstance(peft_model.config, dict)
+            and "_name_or_path" not in peft_model.config
+        ):
+            peft_model.config["_name_or_path"] = None
+
         peft_model.save_pretrained(str(checkpoint_dir / model_key))
 
 

--- a/src/invoke_training/training/_shared/stable_diffusion/validation.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/validation.py
@@ -16,6 +16,7 @@ from diffusers import (
 from transformers import CLIPTextModel, CLIPTokenizer
 
 from invoke_training.config.pipelines.finetune_lora_config import FinetuneLoRASDConfig, FinetuneLoRASDXLConfig
+from invoke_training.training._shared.data.utils.resolution import Resolution
 
 
 def generate_validation_images_sd(
@@ -71,6 +72,8 @@ def generate_validation_images_sd(
         pipeline = pipeline.to(accelerator.device)
     pipeline.set_progress_bar_config(disable=True)
 
+    validation_resolution = Resolution.parse(config.data_loader.image_transforms.resolution)
+
     # Run inference.
     with torch.no_grad():
         for prompt_idx, prompt in enumerate(config.validation_prompts):
@@ -86,8 +89,8 @@ def generate_validation_images_sd(
                             prompt,
                             num_inference_steps=30,
                             generator=generator,
-                            height=config.data_loader.image_transforms.resolution,
-                            width=config.data_loader.image_transforms.resolution,
+                            height=validation_resolution.height,
+                            width=validation_resolution.width,
                         ).images[0]
                     )
 
@@ -170,6 +173,8 @@ def generate_validation_images_sdxl(
         pipeline = pipeline.to(accelerator.device)
     pipeline.set_progress_bar_config(disable=True)
 
+    validation_resolution = Resolution.parse(config.data_loader.image_transforms.resolution)
+
     # Run inference.
     with torch.no_grad():
         for prompt_idx, prompt in enumerate(config.validation_prompts):
@@ -185,8 +190,8 @@ def generate_validation_images_sdxl(
                             prompt,
                             num_inference_steps=30,
                             generator=generator,
-                            height=config.data_loader.image_transforms.resolution,
-                            width=config.data_loader.image_transforms.resolution,
+                            height=validation_resolution.height,
+                            width=validation_resolution.width,
                         ).images[0]
                     )
 

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -33,9 +33,7 @@ from invoke_training.training._shared.data.data_loaders.dreambooth_sd_dataloader
 from invoke_training.training._shared.data.data_loaders.image_caption_sd_dataloader import (
     build_image_caption_sd_dataloader,
 )
-from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import (
-    AspectRatioBucketBatchSampler,
-)
+from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import log_aspect_ratio_buckets
 from invoke_training.training._shared.data.transforms.tensor_disk_cache import TensorDiskCache
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.lora_checkpoint_utils import (
@@ -140,20 +138,6 @@ def cache_vae_outputs(cache_dir: str, data_loader: DataLoader, vae: AutoencoderK
                     "crop_top_left_yx": data_batch["crop_top_left_yx"][i],
                 },
             )
-
-
-def log_aspect_ratio_buckets(logger: logging.Logger, batch_sampler: AspectRatioBucketBatchSampler):
-    if not isinstance(batch_sampler, AspectRatioBucketBatchSampler):
-        return
-
-    log = "Aspect Ratio Buckets:\n"
-    buckets = batch_sampler.get_buckets()
-    bucket_resolutions = sorted(list(buckets.keys()))
-    for bucket_resolution in bucket_resolutions:
-        bucket_images = buckets[bucket_resolution]
-        log += f"  {bucket_resolution.to_tuple()}: {len(bucket_images)}\n"
-
-    logger.info(log)
 
 
 def train_forward(

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -220,7 +220,8 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
 
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")
-    os.makedirs(out_dir)
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+    os.makedirs(ckpt_dir)
 
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.output.report_to
@@ -434,13 +435,13 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
     epoch_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         max_checkpoints=config.max_checkpoints,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_step",
         max_checkpoints=config.max_checkpoints,
     )

--- a/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
@@ -19,7 +19,7 @@ from invoke_training.training._shared.accelerator.accelerator_utils import (
     initialize_logging,
 )
 from invoke_training.training._shared.checkpoints.checkpoint_tracker import CheckpointTracker
-from invoke_training.training._shared.checkpoints.serialization import load_state_dict, save_state_dict
+from invoke_training.training._shared.checkpoints.serialization import save_state_dict
 from invoke_training.training._shared.data.data_loaders.textual_inversion_sd_dataloader import (
     build_textual_inversion_sd_dataloader,
 )
@@ -27,8 +27,8 @@ from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sa
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sd
 from invoke_training.training._shared.stable_diffusion.textual_inversion import (
-    add_tokens_to_tokenizer,
-    expand_placeholder_token,
+    initialize_placeholder_tokens_from_initial_embedding,
+    initialize_placeholder_tokens_from_initial_phrase,
     initialize_placeholder_tokens_from_initializer_token,
     restore_original_embeddings,
 )
@@ -64,82 +64,60 @@ def _save_ti_embeddings(
     save_state_dict(learned_embeds_dict, save_path)
 
 
-def _initialize_placeholder_tokens_from_initial_embedding(
-    tokenizer: CLIPTokenizer, text_encoder: CLIPTextModel, initial_embedding_file: str, placeholder_tokens: list[str]
-) -> list[int]:
-    base_placeholder_token = placeholder_tokens[0]
-
-    state_dict = load_state_dict(initial_embedding_file)
-    if base_placeholder_token not in state_dict:
-        raise ValueError(
-            f"The initial embedding at '{initial_embedding_file}' does not contain an embedding for placeholder token "
-            f"'{base_placeholder_token}'."
-        )
-
-    embeddings = state_dict[base_placeholder_token]
-    if embeddings.shape[0] != len(placeholder_tokens):
-        raise ValueError(
-            f"The number of initial embeddings in '{initial_embedding_file}' ({embeddings.shape[0]}) does not match "
-            f"the number of placeholder tokens ({len(placeholder_tokens)})."
-        )
-
-    placeholder_token_ids = tokenizer.convert_tokens_to_ids(placeholder_tokens)
-
-    # convert_tokens_to_ids returns a `int | list[int]` type, but since we pass in a list it should always return a
-    # list.
-    assert isinstance(placeholder_token_ids, list)
-
-    # Initialize the newly-added placeholder token(s) with the loaded embeddings.
-    token_embeds = text_encoder.get_input_embeddings().weight.data
-    with torch.no_grad():
-        for i, token_id in enumerate(placeholder_token_ids):
-            token_embeds[token_id] = embeddings[i].clone()
-
-    return placeholder_token_ids
-
-
 def _initialize_placeholder_tokens(
-    placeholder_tokens: list[str],
     config: TextualInversionSDConfig,
     tokenizer: CLIPTokenizer,
     text_encoder: PreTrainedTokenizer,
-) -> list[int]:
+) -> tuple[list[str], list[int]]:
     """Prepare the tokenizer and text_encoder for TI training.
 
     - Add the placeholder tokens to the tokenizer.
     - Add new token embeddings to the text_encoder for each of the placeholder tokens.
     - Initialize the new token embeddings from either an existing token, or an initial TI embedding file.
     """
-
-    add_tokens_to_tokenizer(placeholder_tokens, tokenizer)
-    # Resize the token embeddings as we have added new special tokens to the tokenizer.
-    text_encoder.resize_token_embeddings(len(tokenizer))
-
-    if config.initializer_token is not None and config.initial_embedding_file is not None:
-        raise ValueError(
-            "Both 'initializer_token' and 'initial_embedding_file' are non-None. Only one of these fields should be "
-            "set."
+    if (
+        sum(
+            [
+                config.initializer_token is not None,
+                config.initial_embedding_file is not None,
+                config.initial_phrase is not None,
+            ]
         )
-    elif config.initializer_token is not None:
-        placeholder_token_ids = initialize_placeholder_tokens_from_initializer_token(
+        != 1
+    ):
+        raise ValueError(
+            "Exactly one of 'initializer_token', 'initial_embedding_file', or 'initial_phrase' should be set."
+        )
+
+    if config.initializer_token is not None:
+        placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initializer_token(
             tokenizer=tokenizer,
             text_encoder=text_encoder,
             initializer_token=config.initializer_token,
-            placeholder_tokens=placeholder_tokens,
+            placeholder_token=config.placeholder_token,
+            num_vectors=config.num_vectors,
         )
     elif config.initial_embedding_file is not None:
-        placeholder_token_ids = _initialize_placeholder_tokens_from_initial_embedding(
+        placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initial_embedding(
             tokenizer=tokenizer,
             text_encoder=text_encoder,
             initial_embedding_file=config.initial_embedding_file,
-            placeholder_tokens=placeholder_tokens,
+            placeholder_token=config.placeholder_token,
+            num_vectors=config.num_vectors,
+        )
+    elif config.initial_phrase is not None:
+        placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initial_phrase(
+            tokenizer=tokenizer,
+            text_encoder=text_encoder,
+            initial_phrase=config.initial_phrase,
+            placeholder_token=config.placeholder_token,
         )
     else:
         raise ValueError(
-            "Both 'initializer_token' and 'initial_embedding_file' are None. One of these fields must be set."
+            "Exactly one of 'initializer_token', 'initial_embedding_file', or 'initial_phrase' should be set."
         )
 
-    return placeholder_token_ids
+    return placeholder_tokens, placeholder_token_ids
 
 
 def run_training(config: TextualInversionSDConfig):  # noqa: C901
@@ -175,10 +153,10 @@ def run_training(config: TextualInversionSDConfig):  # noqa: C901
         model_name_or_path=config.model, hf_variant=config.hf_variant
     )
 
-    placeholder_tokens = expand_placeholder_token(config.placeholder_token, config.num_vectors)
-    placeholder_token_ids = _initialize_placeholder_tokens(
-        placeholder_tokens=placeholder_tokens, config=config, tokenizer=tokenizer, text_encoder=text_encoder
+    placeholder_tokens, placeholder_token_ids = _initialize_placeholder_tokens(
+        config=config, tokenizer=tokenizer, text_encoder=text_encoder
     )
+    logger.info(f"Initialized {len(placeholder_tokens)} placeholder tokens: {placeholder_tokens}.")
 
     # All parameters of the VAE, UNet, and text encoder are currently frozen. Just unfreeze the token embeddings in the
     # text encoder.

--- a/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
@@ -23,6 +23,7 @@ from invoke_training.training._shared.checkpoints.serialization import load_stat
 from invoke_training.training._shared.data.data_loaders.textual_inversion_sd_dataloader import (
     build_textual_inversion_sd_dataloader,
 )
+from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import log_aspect_ratio_buckets
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sd
 from invoke_training.training._shared.stable_diffusion.textual_inversion import (
@@ -32,11 +33,7 @@ from invoke_training.training._shared.stable_diffusion.textual_inversion import 
     restore_original_embeddings,
 )
 from invoke_training.training._shared.stable_diffusion.validation import generate_validation_images_sd
-from invoke_training.training.pipelines.stable_diffusion.finetune_lora_sd import (
-    cache_vae_outputs,
-    log_aspect_ratio_buckets,
-    train_forward,
-)
+from invoke_training.training.pipelines.stable_diffusion.finetune_lora_sd import cache_vae_outputs, train_forward
 
 
 def _save_ti_embeddings(

--- a/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
@@ -145,7 +145,8 @@ def _initialize_placeholder_tokens(
 def run_training(config: TextualInversionSDConfig):  # noqa: C901
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")
-    os.makedirs(out_dir)
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+    os.makedirs(ckpt_dir)
 
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.output.report_to
@@ -283,14 +284,14 @@ def run_training(config: TextualInversionSDConfig):  # noqa: C901
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
     epoch_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_step",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
@@ -288,7 +288,8 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
 
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")
-    os.makedirs(out_dir)
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+    os.makedirs(ckpt_dir)
 
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.output.report_to
@@ -521,13 +522,13 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
     epoch_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         max_checkpoints=config.max_checkpoints,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_step",
         max_checkpoints=config.max_checkpoints,
     )

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
@@ -36,6 +36,7 @@ from invoke_training.training._shared.data.data_loaders.dreambooth_sd_dataloader
 from invoke_training.training._shared.data.data_loaders.image_caption_sd_dataloader import (
     build_image_caption_sd_dataloader,
 )
+from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import log_aspect_ratio_buckets
 from invoke_training.training._shared.data.transforms.tensor_disk_cache import TensorDiskCache
 from invoke_training.training._shared.data.utils.resolution import Resolution
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
@@ -466,6 +467,8 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
         text_encoder_output_cache_dir=text_encoder_output_cache_dir_name,
         vae_output_cache_dir=vae_output_cache_dir_name,
     )
+
+    log_aspect_ratio_buckets(logger=logger, batch_sampler=data_loader.batch_sampler)
 
     # TODO(ryand): Test in a distributed training environment and more clearly document the rationale for scaling steps
     # by the number of processes. This scaling logic was copied from the diffusers example training code, but it appears

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
@@ -37,6 +37,7 @@ from invoke_training.training._shared.data.data_loaders.image_caption_sd_dataloa
     build_image_caption_sd_dataloader,
 )
 from invoke_training.training._shared.data.transforms.tensor_disk_cache import TensorDiskCache
+from invoke_training.training._shared.data.utils.resolution import Resolution
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.lora_checkpoint_utils import (
     TEXT_ENCODER_TARGET_MODULES,
@@ -187,7 +188,7 @@ def train_forward(
     text_encoder_2: CLIPPreTrainedModel,
     unet: UNet2DConditionModel,
     weight_dtype: torch.dtype,
-    resolution: int,
+    resolution: int | tuple[int, int],
     prediction_type=None,
 ):
     """Run the forward training pass for a single data_batch.
@@ -225,7 +226,7 @@ def train_forward(
     # it is a result of the fact that the original size and crop values get concatenated with the time embeddings.
     def compute_time_ids(original_size, crops_coords_top_left):
         # Adapted from pipeline.StableDiffusionXLPipeline._get_add_time_ids
-        target_size = (resolution, resolution)
+        target_size = Resolution.parse(resolution).to_tuple()
         add_time_ids = list(original_size + crops_coords_top_left + target_size)
         add_time_ids = torch.tensor([add_time_ids])
         add_time_ids = add_time_ids.to(accelerator.device, dtype=weight_dtype)

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
@@ -28,8 +28,7 @@ from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sa
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training.training._shared.stable_diffusion.textual_inversion import (
-    add_tokens_to_tokenizer,
-    expand_placeholder_token,
+    initialize_placeholder_tokens_from_initial_phrase,
     initialize_placeholder_tokens_from_initializer_token,
     restore_original_embeddings,
 )
@@ -75,13 +74,12 @@ def _save_ti_embeddings(
 
 
 def _initialize_placeholder_tokens(
-    placeholder_tokens: list[str],
     config: TextualInversionSDXLConfig,
     tokenizer_1: CLIPTokenizer,
     tokenizer_2: CLIPTokenizer,
     text_encoder_1: PreTrainedTokenizer,
     text_encoder_2: PreTrainedTokenizer,
-) -> tuple[list[int], list[int]]:
+) -> tuple[list[str], list[int], list[int]]:
     """Prepare the tokenizers and text_encoders for TI training.
 
     - Add the placeholder tokens to the tokenizers.
@@ -89,39 +87,58 @@ def _initialize_placeholder_tokens(
     - Initialize the new token embeddings from either an existing token, or an initial TI embedding file.
     """
 
-    add_tokens_to_tokenizer(placeholder_tokens, tokenizer_1)
-    add_tokens_to_tokenizer(placeholder_tokens, tokenizer_2)
-    # Resize the token embeddings as we have added new special tokens to the tokenizer.
-    text_encoder_1.resize_token_embeddings(len(tokenizer_1))
-    text_encoder_2.resize_token_embeddings(len(tokenizer_2))
-
-    if config.initializer_token is not None and config.initial_embedding_file is not None:
-        raise ValueError(
-            "Both 'initializer_token' and 'initial_embedding_file' are non-None. Only one of these fields should be "
-            "set."
+    if (
+        sum(
+            [
+                config.initializer_token is not None,
+                config.initial_embedding_file is not None,
+                config.initial_phrase is not None,
+            ]
         )
-    elif config.initializer_token is not None:
-        placeholder_token_ids_1 = initialize_placeholder_tokens_from_initializer_token(
+        != 1
+    ):
+        raise ValueError(
+            "Exactly one of 'initializer_token', 'initial_embedding_file', or 'initial_phrase' should be set."
+        )
+
+    if config.initializer_token is not None:
+        placeholder_tokens_1, placeholder_token_ids_1 = initialize_placeholder_tokens_from_initializer_token(
             tokenizer=tokenizer_1,
             text_encoder=text_encoder_1,
             initializer_token=config.initializer_token,
-            placeholder_tokens=placeholder_tokens,
+            placeholder_token=config.placeholder_token,
+            num_vectors=config.num_vectors,
         )
-        placeholder_token_ids_2 = initialize_placeholder_tokens_from_initializer_token(
+        placeholder_tokens_2, placeholder_token_ids_2 = initialize_placeholder_tokens_from_initializer_token(
             tokenizer=tokenizer_2,
             text_encoder=text_encoder_2,
             initializer_token=config.initializer_token,
-            placeholder_tokens=placeholder_tokens,
+            placeholder_token=config.placeholder_token,
+            num_vectors=config.num_vectors,
         )
     elif config.initial_embedding_file is not None:
         # TODO(ryan)
         raise NotImplementedError("Initializing from an initial embedding is not yet supported for SDXL.")
+    elif config.initial_phrase is not None:
+        placeholder_tokens_1, placeholder_token_ids_1 = initialize_placeholder_tokens_from_initial_phrase(
+            tokenizer=tokenizer_1,
+            text_encoder=text_encoder_1,
+            initial_phrase=config.initial_phrase,
+            placeholder_token=config.placeholder_token,
+        )
+        placeholder_tokens_2, placeholder_token_ids_2 = initialize_placeholder_tokens_from_initial_phrase(
+            tokenizer=tokenizer_2,
+            text_encoder=text_encoder_2,
+            initial_phrase=config.initial_phrase,
+            placeholder_token=config.placeholder_token,
+        )
     else:
         raise ValueError(
-            "Both 'initializer_token' and 'initial_embedding_file' are None. One of these fields must be set."
+            "Exactly one of 'initializer_token', 'initial_embedding_file', or 'initial_phrase' should be set."
         )
 
-    return placeholder_token_ids_1, placeholder_token_ids_2
+    assert placeholder_tokens_1 == placeholder_tokens_2
+    return placeholder_tokens_1, placeholder_token_ids_1, placeholder_token_ids_2
 
 
 def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
@@ -157,15 +174,14 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
         model_name_or_path=config.model, hf_variant=config.hf_variant, vae_model=config.vae_model
     )
 
-    placeholder_tokens = expand_placeholder_token(config.placeholder_token, config.num_vectors)
-    placeholder_token_ids_1, placeholder_token_ids_2 = _initialize_placeholder_tokens(
-        placeholder_tokens=placeholder_tokens,
+    placeholder_tokens, placeholder_token_ids_1, placeholder_token_ids_2 = _initialize_placeholder_tokens(
         config=config,
         tokenizer_1=tokenizer_1,
         tokenizer_2=tokenizer_2,
         text_encoder_1=text_encoder_1,
         text_encoder_2=text_encoder_2,
     )
+    logger.info(f"Initialized {len(placeholder_tokens)} placeholder tokens: {placeholder_tokens}.")
 
     # All parameters of the VAE, UNet, and text encoder are currently frozen. Just unfreeze the token embeddings in the
     # text encoders.

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
@@ -24,6 +24,7 @@ from invoke_training.training._shared.checkpoints.serialization import save_stat
 from invoke_training.training._shared.data.data_loaders.textual_inversion_sd_dataloader import (
     build_textual_inversion_sd_dataloader,
 )
+from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import log_aspect_ratio_buckets
 from invoke_training.training._shared.optimizer.optimizer_utils import initialize_optimizer
 from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training.training._shared.stable_diffusion.textual_inversion import (
@@ -237,6 +238,8 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
         batch_size=config.train_batch_size,
         vae_output_cache_dir=vae_output_cache_dir_name,
     )
+
+    log_aspect_ratio_buckets(logger=logger, batch_sampler=data_loader.batch_sampler)
 
     # TODO(ryand): Test in a distributed training environment and more clearly document the rationale for scaling steps
     # by the number of processes. This scaling logic was copied from the diffusers example training code, but it appears

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
@@ -127,7 +127,8 @@ def _initialize_placeholder_tokens(
 def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.output.base_output_dir, f"{time.time()}")
-    os.makedirs(out_dir)
+    ckpt_dir = os.path.join(out_dir, "checkpoints")
+    os.makedirs(ckpt_dir)
 
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.output.report_to
@@ -275,14 +276,14 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
     epoch_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
-        base_dir=out_dir,
+        base_dir=ckpt_dir,
         prefix="checkpoint_step",
         extension=f".{config.output.save_model_as}",
         max_checkpoints=config.max_checkpoints,

--- a/tests/invoke_training/training/_shared/data/transforms/test_caption_prefix_transform.py
+++ b/tests/invoke_training/training/_shared/data/transforms/test_caption_prefix_transform.py
@@ -1,0 +1,11 @@
+from invoke_training.training._shared.data.transforms.caption_prefix_transform import CaptionPrefixTransform
+
+
+def test_caption_prefix_transform():
+    tf = CaptionPrefixTransform(caption_field_name="caption", prefix="prefix ")
+
+    in_example = {"caption": "original caption", "other": 2}
+
+    out_example = tf(in_example)
+
+    assert out_example == {"caption": "prefix original caption", "other": 2}

--- a/tests/invoke_training/training/_shared/data/transforms/test_template_caption_transform.py
+++ b/tests/invoke_training/training/_shared/data/transforms/test_template_caption_transform.py
@@ -1,12 +1,12 @@
 import pytest
 
-from invoke_training.training._shared.data.transforms.textual_inversion_caption_transform import (
-    TextualInversionCaptionTransform,
+from invoke_training.training._shared.data.transforms.template_caption_transform import (
+    TemplateCaptionTransform,
 )
 
 
-def test_textual_inversion_caption_transform():
-    tf = TextualInversionCaptionTransform(
+def test_template_caption_transform():
+    tf = TemplateCaptionTransform(
         field_name="test_field", placeholder_str="placeholder", caption_templates=["template 1 {}"]
     )
 
@@ -17,11 +17,11 @@ def test_textual_inversion_caption_transform():
     assert out_example == {"existing": 2, "test_field": "template 1 placeholder"}
 
 
-def test_textual_inversion_caption_transform_seed():
+def test_template_caption_transform_seed():
     field_name = "test_field"
     placeholder_str = "placeholder"
     caption_templates = ["template 1 {}", "template 2 {}"]
-    tf = TextualInversionCaptionTransform(
+    tf = TemplateCaptionTransform(
         field_name=field_name,
         placeholder_str=placeholder_str,
         caption_templates=caption_templates,
@@ -32,7 +32,7 @@ def test_textual_inversion_caption_transform_seed():
     out_examples = [tf({}) for _ in range(10)]
 
     # Run on 10 examples with same seed and assert that results match.
-    tf = TextualInversionCaptionTransform(
+    tf = TemplateCaptionTransform(
         field_name=field_name,
         placeholder_str=placeholder_str,
         caption_templates=caption_templates,
@@ -42,7 +42,7 @@ def test_textual_inversion_caption_transform_seed():
     assert out_examples == out_examples_same_seed
 
     # Run on 10 examples with a different seed and assert that the results don't match.
-    tf = TextualInversionCaptionTransform(
+    tf = TemplateCaptionTransform(
         field_name=field_name,
         placeholder_str=placeholder_str,
         caption_templates=caption_templates,
@@ -52,8 +52,8 @@ def test_textual_inversion_caption_transform_seed():
     assert out_examples != out_examples_diff_seed
 
 
-def test_textual_inversion_caption_transform_bad_templates():
-    tf = TextualInversionCaptionTransform(
+def test_template_caption_transform_bad_templates():
+    tf = TemplateCaptionTransform(
         field_name="test_field", placeholder_str="placeholder", caption_templates=["template 1"]
     )
 

--- a/tests/invoke_training/training/_shared/stable_diffusion/test_textual_inversion.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/test_textual_inversion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from invoke_training.training._shared.stable_diffusion.textual_inversion import expand_placeholder_token
+from invoke_training.training._shared.stable_diffusion.textual_inversion import _expand_placeholder_token
 
 
 @pytest.mark.parametrize(
@@ -8,9 +8,9 @@ from invoke_training.training._shared.stable_diffusion.textual_inversion import 
     [("abc", 1, ["abc"]), ("abc", 2, ["abc", "abc_1"]), ("abc", 3, ["abc", "abc_1", "abc_2"])],
 )
 def test_expand_placeholder_token(placeholder_token: str, num_vectors: int, expected_placeholder_tokens: list[str]):
-    assert expand_placeholder_token(placeholder_token, num_vectors) == expected_placeholder_tokens
+    assert _expand_placeholder_token(placeholder_token, num_vectors) == expected_placeholder_tokens
 
 
 def test_expand_placeholder_token_raises_on_invalid_num_vectors():
     with pytest.raises(ValueError):
-        expand_placeholder_token("abc", 0)
+        _expand_placeholder_token("abc", 0)


### PR DESCRIPTION
- Add `initial_phrase` config option to initialize TI embeddings from a phrase rather than a single token.
- Add option to train TI by adding the placeholder token(s) as a prefix to existing captions.
- Create a `checkpoints/` subdirectory in the output directory.
- Add support for training with non-square target resolution.
- Add workaround for PEFT saving with non-diffusers base models.