### PR TITLE
Add `base_embeddings` config parameter for LoRA finetuning pipelines

### DIFF
--- a/src/invoke_training/config/pipelines/finetune_lora_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_config.py
@@ -22,6 +22,24 @@ class LoRATrainingConfig(BasePipelineConfig):
     """The Hugging Face Hub model variant to use. Only applies if `model` is a Hugging Face Hub model name.
     """
 
+    # Note: Pydantic handles mutable default values well:
+    # https://docs.pydantic.dev/latest/concepts/models/#fields-with-non-hashable-default-values
+    base_embeddings: dict[str, str] = {}
+    """A mapping of embedding tokens to trained embedding file paths. These embeddings will be applied to the base model
+    before training.
+
+    Example:
+    ```
+    base_embeddings = {
+        "bruce_the_gnome": "/path/to/bruce_the_gnome.safetensors",
+    }
+    ```
+
+    Note that the embeddings themselves are not fine-tuned further, but they will impact the LoRA model training if they
+    are referenced in the dataset captions. The list of embeddings provided here should be the same list used at
+    generation time with the resultant LoRA model.
+    """
+
     train_unet: bool = True
     """Whether to add LoRA layers to the UNet model and train it.
     """

--- a/src/invoke_training/config/pipelines/finetune_lora_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_config.py
@@ -35,6 +35,9 @@ class LoRATrainingConfig(BasePipelineConfig):
     }
     ```
 
+    Consider also adding the embedding tokens to the `data_loader.caption_prefix` if they are not already present in the
+    dataset captions.
+
     Note that the embeddings themselves are not fine-tuned further, but they will impact the LoRA model training if they
     are referenced in the dataset captions. The list of embeddings provided here should be the same list used at
     generation time with the resultant LoRA model.

--- a/src/invoke_training/config/shared/data/data_loader_config.py
+++ b/src/invoke_training/config/shared/data/data_loader_config.py
@@ -53,6 +53,10 @@ class ImageCaptionSDDataLoaderConfig(ConfigBaseModel):
 
     aspect_ratio_buckets: AspectRatioBucketConfig | None = None
 
+    caption_prefix: str | None = None
+    """A prefix that will be prepended to all captions. If None, no prefix will be added.
+    """
+
     dataloader_num_workers: int = 0
     """Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
     """

--- a/src/invoke_training/scripts/invoke_visualize_data_loading.py
+++ b/src/invoke_training/scripts/invoke_visualize_data_loading.py
@@ -107,7 +107,7 @@ def main():
     elif data_loader_config.type == "TEXTUAL_INVERSION_SD_DATA_LOADER":
         data_loader = build_textual_inversion_sd_dataloader(
             config=data_loader_config,
-            placeholder_tokens=["<placeholder_tokens_are_not_shown_when_visualizing>"],
+            placeholder_token=["<placeholder_token_not_shown_when_visualizing>"],
             batch_size=train_config.train_batch_size,
             shuffle=False,
         )

--- a/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
+++ b/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
@@ -215,7 +215,7 @@ def run_training(config: DirectPreferenceOptimizationLoRASDConfig):  # noqa: C90
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path=config.model, hf_variant=config.hf_variant
+        model_name_or_path=config.model, hf_variant=config.hf_variant, base_embeddings=config.base_embeddings
     )
     ref_text_encoder = copy.deepcopy(text_encoder)
     ref_unet = copy.deepcopy(unet)

--- a/src/invoke_training/training/_shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/training/_shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -19,6 +19,7 @@ from invoke_training.training._shared.data.datasets.transform_dataset import Tra
 from invoke_training.training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import (
     AspectRatioBucketBatchSampler,
 )
+from invoke_training.training._shared.data.transforms.caption_prefix_transform import CaptionPrefixTransform
 from invoke_training.training._shared.data.transforms.drop_field_transform import DropFieldTransform
 from invoke_training.training._shared.data.transforms.load_cache_transform import LoadCacheTransform
 from invoke_training.training._shared.data.transforms.sd_image_transform import SDImageTransform
@@ -115,6 +116,10 @@ def build_image_caption_sd_dataloader(
         )
 
     all_transforms = []
+
+    if config.caption_prefix is not None:
+        all_transforms.append(CaptionPrefixTransform(caption_field_name="caption", prefix=config.caption_prefix + " "))
+
     if vae_output_cache_dir is None:
         all_transforms.append(
             SDImageTransform(

--- a/src/invoke_training/training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
+++ b/src/invoke_training/training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
@@ -96,7 +96,7 @@ def get_preset_ti_caption_templates(preset: Literal["object", "style"]) -> list[
 
 def build_textual_inversion_sd_dataloader(  # noqa: C901
     config: TextualInversionSDDataLoaderConfig,
-    placeholder_tokens: list[str],
+    placeholder_token: str,
     batch_size: int,
     vae_output_cache_dir: Optional[str] = None,
     shuffle: bool = True,
@@ -105,7 +105,7 @@ def build_textual_inversion_sd_dataloader(  # noqa: C901
 
     Args:
         config (TextualInversionSDDataLoaderConfig): The dataset config.
-        placeholder_tokens (list[str]): The placeholder tokens being trained.
+        placeholder_token (str): The placeholder token being trained.
         batch_size (int): The DataLoader batch size.
         vae_output_cache_dir (str, optional): The directory where VAE outputs are cached and should be loaded from. If
             set, then the image augmentation transforms will be skipped, and the image will not be copied to VRAM.
@@ -113,8 +113,6 @@ def build_textual_inversion_sd_dataloader(  # noqa: C901
     Returns:
         DataLoader
     """
-    placeholder_str = " ".join(placeholder_tokens)
-
     if isinstance(config.dataset, HFHubImageCaptionDatasetConfig):
         base_dataset = build_hf_hub_image_caption_dataset(config.dataset)
     elif isinstance(config.dataset, HFDirImageCaptionDatasetConfig):
@@ -130,20 +128,20 @@ def build_textual_inversion_sd_dataloader(  # noqa: C901
         # Overwrites the caption field. Typically used with a ImageDirDataset that does not have captions.
         caption_tf = TemplateCaptionTransform(
             field_name="caption",
-            placeholder_str=placeholder_str,
+            placeholder_str=placeholder_token,
             caption_templates=config.captions.templates,
         )
     elif isinstance(config.captions, TextualInversionPresetCaptionTransformConfig):
         # Overwrites the caption field. Typically used with a ImageDirDataset that does not have captions.
         caption_tf = TemplateCaptionTransform(
             field_name="caption",
-            placeholder_str=placeholder_str,
+            placeholder_str=placeholder_token,
             caption_templates=get_preset_ti_caption_templates(config.captions.preset),
         )
     elif isinstance(config.captions, TextualInversionCaptionPrefixTransformConfig):
         # Prefixes the caption field. Must be used with a HFHubImageCaptionDataset or HFDirImageCaptionDataset that
         # already has captions.
-        caption_tf = CaptionPrefixTransform(caption_field_name="caption", prefix=placeholder_str + " ")
+        caption_tf = CaptionPrefixTransform(caption_field_name="caption", prefix=placeholder_token + " ")
     else:
         raise ValueError(f"Unexpected caption config type: '{type(config.captions)}'.")
 

--- a/src/invoke_training/training/_shared/stable_diffusion/tokenize_captions.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/tokenize_captions.py
@@ -1,6 +1,8 @@
 import torch
 from transformers import CLIPTokenizer
 
+from invoke_training.training._shared.stable_diffusion.textual_inversion import expand_placeholders_in_caption
+
 
 def tokenize_captions(tokenizer: CLIPTokenizer, captions: list[str]) -> torch.Tensor:
     """Tokenize a list of caption.
@@ -14,6 +16,7 @@ def tokenize_captions(tokenizer: CLIPTokenizer, captions: list[str]) -> torch.Te
     """
     caption_token_ids = []
     for caption in captions:
+        caption = expand_placeholders_in_caption(caption, tokenizer)
         input = tokenizer(
             caption,
             max_length=tokenizer.model_max_length,

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -247,7 +247,7 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path=config.model, hf_variant=config.hf_variant
+        model_name_or_path=config.model, hf_variant=config.hf_variant, base_embeddings=config.base_embeddings
     )
 
     if config.xformers:

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -335,7 +335,6 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
         return peft_model
 
     # Add LoRA layers to the model.
-    trainable_param_groups = []
     if config.train_unet:
         unet_lora_config = peft.LoraConfig(
             r=config.lora_rank_dim,

--- a/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
@@ -200,7 +200,7 @@ def run_training(config: TextualInversionSDConfig):  # noqa: C901
             vae.to(accelerator.device, dtype=weight_dtype)
             data_loader = build_textual_inversion_sd_dataloader(
                 config=config.data_loader,
-                placeholder_tokens=placeholder_tokens,
+                placeholder_token=config.placeholder_token,
                 batch_size=config.train_batch_size,
                 shuffle=False,
             )
@@ -220,7 +220,7 @@ def run_training(config: TextualInversionSDConfig):  # noqa: C901
 
     data_loader = build_textual_inversion_sd_dataloader(
         config=config.data_loader,
-        placeholder_tokens=placeholder_tokens,
+        placeholder_token=config.placeholder_token,
         batch_size=config.train_batch_size,
         vae_output_cache_dir=vae_output_cache_dir_name,
     )

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
@@ -315,7 +315,10 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
-        model_name_or_path=config.model, hf_variant=config.hf_variant, vae_model=config.vae_model
+        model_name_or_path=config.model,
+        hf_variant=config.hf_variant,
+        vae_model=config.vae_model,
+        base_embeddings=config.base_embeddings,
     )
 
     if config.xformers:

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
@@ -226,7 +226,7 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
             vae.to(accelerator.device, dtype=weight_dtype)
             data_loader = build_textual_inversion_sd_dataloader(
                 config=config.data_loader,
-                placeholder_tokens=placeholder_tokens,
+                placeholder_token=config.placeholder_token,
                 batch_size=config.train_batch_size,
                 shuffle=False,
             )
@@ -251,7 +251,7 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
 
     data_loader = build_textual_inversion_sd_dataloader(
         config=config.data_loader,
-        placeholder_tokens=placeholder_tokens,
+        placeholder_token=config.placeholder_token,
         batch_size=config.train_batch_size,
         vae_output_cache_dir=vae_output_cache_dir_name,
     )

--- a/tests/invoke_training/training/_shared/data/data_loaders/test_textual_inversion_sd_dataloader.py
+++ b/tests/invoke_training/training/_shared/data/data_loaders/test_textual_inversion_sd_dataloader.py
@@ -21,10 +21,10 @@ def test_build_textual_inversion_sd_dataloader(image_dir):  # noqa: F811
         captions=TextualInversionPresetCaptionTransformConfig(preset="object"),
         image_transforms=SDImageTransformConfig(resolution=512),
     )
-    placeholder_tokens = ["placeholder", "placeholder_1"]
+
     data_loader = build_textual_inversion_sd_dataloader(
         config=config,
-        placeholder_tokens=placeholder_tokens,
+        placeholder_token="placeholder",
         batch_size=2,
     )
 
@@ -39,8 +39,7 @@ def test_build_textual_inversion_sd_dataloader(image_dir):  # noqa: F811
 
     assert len(example["caption"]) == 2
     for caption in example["caption"]:
-        for placeholder_token in placeholder_tokens:
-            assert placeholder_token in caption
+        assert "placeholder" in caption
 
     original_size_hw = example["original_size_hw"]
     assert len(original_size_hw) == 2

--- a/tests/invoke_training/training/_shared/stable_diffusion/test_model_loading_utils.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/test_model_loading_utils.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import CLIPTextModel, CLIPTokenizer
+
+from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sd, load_models_sdxl
+
+from .ti_embedding_checkpoint_fixture import sdv1_embedding_path, sdxl_embedding_path  # noqa: F401
+
+
+@pytest.mark.loads_model
+def test_load_models_sd(sdv1_embedding_path):  # noqa: F811
+    model_name = "runwayml/stable-diffusion-v1-5"
+
+    tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        model_name_or_path=model_name,
+        hf_variant="fp16",
+        base_embeddings={"special_test_token": str(sdv1_embedding_path)},
+    )
+
+    token_ids = tokenizer.encode("special_test_token special_test_token_1", add_special_tokens=False)
+    assert len(token_ids) == 2
+
+    token_embeds = text_encoder.get_input_embeddings().weight.data
+    for token_id in token_ids:
+        # The embedding should be all zeros, because that is how it was initialized in the sdv1_embedding_path
+        # fixture.
+        assert torch.allclose(token_embeds[token_id], torch.zeros_like(token_embeds[token_id]))
+
+
+@pytest.mark.loads_model
+def test_load_models_sdxl(sdxl_embedding_path: Path):  # noqa: F811
+    model_name = "stabilityai/stable-diffusion-xl-base-1.0"
+
+    tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
+        model_name_or_path=model_name,
+        hf_variant="fp16",
+        base_embeddings={"special_test_token": str(sdxl_embedding_path)},
+    )
+
+    # Validate that the embeddings were applied correctly.
+    def validate_ti_embeddings(tokenizer: CLIPTokenizer, text_encoder: CLIPTextModel):
+        token_ids = tokenizer.encode("special_test_token special_test_token_1", add_special_tokens=False)
+        assert len(token_ids) == 2
+
+        token_embeds = text_encoder.get_input_embeddings().weight.data
+        for token_id in token_ids:
+            # The embedding should be all zeros, because that is how it was initialized in the sdxl_embedding_path
+            # fixture.
+            assert torch.allclose(token_embeds[token_id], torch.zeros_like(token_embeds[token_id]))
+
+    validate_ti_embeddings(tokenizer_1, text_encoder_1)
+    validate_ti_embeddings(tokenizer_2, text_encoder_2)

--- a/tests/invoke_training/training/_shared/stable_diffusion/ti_embedding_checkpoint_fixture.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/ti_embedding_checkpoint_fixture.py
@@ -20,3 +20,24 @@ def sdv1_embedding_path(tmp_path_factory: pytest.TempPathFactory):
     save_state_dict(embedding_state_dict, embedding_path)
 
     return embedding_path
+
+
+@pytest.fixture(scope="session")
+def sdxl_embedding_path(tmp_path_factory: pytest.TempPathFactory):
+    """A fixture that writes a dummy SDXL TI embedding to a temp dir and returns the embedding path.
+
+    Note that the 'session' scope is used to share the same directory across all tests in a session. Refer to
+    https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#the-tmp-path-factory-fixture for details on the use of
+    tmp_path_factory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("embeddings")
+
+    embedding_state_dict = {
+        "clip_l": torch.zeros((2, 768)),
+        "clip_g": torch.zeros((2, 1280)),
+    }
+
+    embedding_path = tmp_dir / "embedding.safetensors"
+    save_state_dict(embedding_state_dict, embedding_path)
+
+    return embedding_path


### PR DESCRIPTION
- Add `base_embeddings` config parameter for LoRA finetuning pipelines. This enables training a LoRA model on top of trained TI embedding.
- Add model loading unit tests for this new functionality.