### PR TITLE
Fix bug in TI initialization from `initial_phrase`

### DIFF
--- a/src/invoke_training/training/_shared/stable_diffusion/textual_inversion.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/textual_inversion.py
@@ -75,6 +75,7 @@ def initialize_placeholder_tokens_from_initial_phrase(
 
     # Expand the tokenizer / text_encoder to include one placeholder token for each token in the initial_phrase.
     placeholder_tokens = _expand_placeholder_token(placeholder_token, num_vectors=len(initial_token_ids))
+    _add_tokens_to_tokenizer(placeholder_tokens, tokenizer)
     # Resize the token embeddings as we have added new special tokens to the tokenizer.
     text_encoder.resize_token_embeddings(len(tokenizer))
     placeholder_token_ids = tokenizer.convert_tokens_to_ids(placeholder_tokens)

--- a/tests/invoke_training/training/_shared/stable_diffusion/test_textual_inversion.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/test_textual_inversion.py
@@ -1,6 +1,17 @@
-import pytest
+from pathlib import Path
 
-from invoke_training.training._shared.stable_diffusion.textual_inversion import _expand_placeholder_token
+import pytest
+import torch
+
+from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sd
+from invoke_training.training._shared.stable_diffusion.textual_inversion import (
+    _expand_placeholder_token,
+    initialize_placeholder_tokens_from_initial_embedding,
+    initialize_placeholder_tokens_from_initial_phrase,
+    initialize_placeholder_tokens_from_initializer_token,
+)
+
+from .ti_embedding_checkpoint_fixture import sdv1_embedding_path  # noqa: F401
 
 
 @pytest.mark.parametrize(
@@ -14,3 +25,87 @@ def test_expand_placeholder_token(placeholder_token: str, num_vectors: int, expe
 def test_expand_placeholder_token_raises_on_invalid_num_vectors():
     with pytest.raises(ValueError):
         _expand_placeholder_token("abc", 0)
+
+
+@pytest.mark.loads_model
+def test_initialize_placeholder_tokens_from_initializer_token():
+    tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+    )
+
+    initializer_token = "dog"
+    num_vectors = 2
+    placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initializer_token(
+        tokenizer=tokenizer,
+        text_encoder=text_encoder,
+        initializer_token=initializer_token,
+        placeholder_token="dog_placeholder",
+        num_vectors=num_vectors,
+    )
+
+    assert len(placeholder_tokens) == num_vectors
+    assert len(placeholder_token_ids) == num_vectors
+    assert placeholder_tokens == ["dog_placeholder", "dog_placeholder_1"]
+
+    token_embeds = text_encoder.get_input_embeddings().weight.data
+    initializer_token_id = tokenizer.encode(initializer_token, add_special_tokens=False)[0]
+    with torch.no_grad():
+        for placeholder_token_id in placeholder_token_ids:
+            assert torch.allclose(token_embeds[placeholder_token_id], token_embeds[initializer_token_id])
+
+
+@pytest.mark.loads_model
+def test_initialize_placeholder_tokens_from_initial_phrase():
+    tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+    )
+
+    initial_phrase = "little brown dog"
+    placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initial_phrase(
+        tokenizer=tokenizer,
+        text_encoder=text_encoder,
+        initial_phrase=initial_phrase,
+        placeholder_token="dog_placeholder",
+    )
+
+    expected_num_vectors = 3
+    assert len(placeholder_tokens) == expected_num_vectors
+    assert len(placeholder_token_ids) == expected_num_vectors
+    assert placeholder_tokens == ["dog_placeholder", "dog_placeholder_1", "dog_placeholder_2"]
+
+    token_embeds = text_encoder.get_input_embeddings().weight.data
+    initial_token_ids = tokenizer.encode(initial_phrase, add_special_tokens=False)
+    assert len(initial_token_ids) == expected_num_vectors
+    with torch.no_grad():
+        for placeholder_token_id, initial_token_id in zip(placeholder_token_ids, initial_token_ids):
+            assert torch.allclose(token_embeds[placeholder_token_id], token_embeds[initial_token_id])
+
+
+@pytest.mark.loads_model
+def test_initialize_placeholder_tokens_from_initial_embedding(sdv1_embedding_path: Path):  # noqa: F811
+    tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+    )
+
+    placeholder_token = "custom_token"
+    num_vectors = 2
+    placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initial_embedding(
+        tokenizer=tokenizer,
+        text_encoder=text_encoder,
+        initial_embedding_file=str(sdv1_embedding_path),
+        placeholder_token=placeholder_token,
+        num_vectors=num_vectors,
+    )
+
+    assert len(placeholder_tokens) == num_vectors
+    assert len(placeholder_token_ids) == num_vectors
+    assert placeholder_tokens == ["custom_token", "custom_token_1"]
+
+    token_embeds = text_encoder.get_input_embeddings().weight.data
+    with torch.no_grad():
+        for placeholder_token_id in placeholder_token_ids:
+            # The placeholder embeddings should be initialized to zero, because this is how they are initialized in the
+            # dummy sdv1_embedding_path checkpoint.
+            assert torch.allclose(
+                token_embeds[placeholder_token_id], torch.zeros_like(token_embeds[placeholder_token_id])
+            )

--- a/tests/invoke_training/training/_shared/stable_diffusion/ti_embedding_checkpoint_fixture.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/ti_embedding_checkpoint_fixture.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from invoke_training.training._shared.checkpoints.serialization import save_state_dict
+
+
+@pytest.fixture(scope="session")
+def sdv1_embedding_path(tmp_path_factory: pytest.TempPathFactory):
+    """A fixture that writes a dummy SD v1 TI embedding to a temp dir and returns the embedding path.
+
+    Note that the 'session' scope is used to share the same directory across all tests in a session. Refer to
+    https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#the-tmp-path-factory-fixture for details on the use of
+    tmp_path_factory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("embeddings")
+
+    embedding_state_dict = {"custom_token": torch.zeros((2, 768))}
+
+    embedding_path = tmp_dir / "embedding.safetensors"
+    save_state_dict(embedding_state_dict, embedding_path)
+
+    return embedding_path


### PR DESCRIPTION
- Fixed a bug when initializing TI training with the `initial_phrase` configuration. Prior to this fix, all placeholder tokens were being initialized with the same embedding.
- Added unit tests for all `initialize_placeholder_tokens_from_*(...)` functions top catch this sort of thing in the future.