### PR TITLE
Add `keep_original_captions` config for the TI dataloader

### DIFF
--- a/configs/finetune_lora_and_ti_sdxl_pokemon_1x24gb_example.yaml
+++ b/configs/finetune_lora_and_ti_sdxl_pokemon_1x24gb_example.yaml
@@ -22,7 +22,11 @@ data_loader:
   dataset:
     type: HF_HUB_IMAGE_CAPTION_DATASET
     dataset_name: lambdalabs/pokemon-blip-captions
-  apply_caption_prefix: True
+  # We just use a single simple caption template here. keep_original_captions is set to True, so this effectively
+  # prepends the placeholder token to the original caption.
+  caption_templates:
+    - "{}"
+  keep_original_captions: True
   resolution: 512
   center_crop: True
   random_flip: False

--- a/src/invoke_training/config/shared/data/data_loader_config.py
+++ b/src/invoke_training/config/shared/data/data_loader_config.py
@@ -124,8 +124,10 @@ class TextualInversionSDDataLoaderConfig(ConfigBaseModel):
     - "a cropped photo of the {}"
     """
 
-    # TODO(ryand): Replace this with keep_original_captions config.
-    apply_caption_prefix: bool = False
+    keep_original_captions: bool = False
+    """If `True`, then the captions generated as a result of the `caption_preset` or `caption_templates` will be used as
+    prefixes for the original captions. If `False`, then the generated captions will replace the original captions.
+    """
 
     aspect_ratio_buckets: AspectRatioBucketConfig | None = None
     """The aspect ratio bucketing configuration. If None, aspect ratio bucketing is disabled, and all images will be

--- a/src/invoke_training/training/_shared/data/transforms/concat_fields_transform.py
+++ b/src/invoke_training/training/_shared/data/transforms/concat_fields_transform.py
@@ -1,0 +1,15 @@
+import typing
+
+
+class ConcatFieldsTransform:
+    """A transform that concatenate multiple string fields."""
+
+    def __init__(self, src_field_names: list[str], dst_field_name: str, separator: str = " "):
+        self._src_field_names = src_field_names
+        self._dst_field_name = dst_field_name
+        self._separator = separator
+
+    def __call__(self, data: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        result = self._separator.join([data[field_name] for field_name in self._src_field_names])
+        data[self._dst_field_name] = result
+        return data

--- a/tests/invoke_training/training/_shared/data/data_loaders/test_textual_inversion_sd_dataloader.py
+++ b/tests/invoke_training/training/_shared/data/data_loaders/test_textual_inversion_sd_dataloader.py
@@ -1,7 +1,7 @@
 import torch
 
 from invoke_training.config.shared.data.data_loader_config import TextualInversionSDDataLoaderConfig
-from invoke_training.config.shared.data.dataset_config import ImageDirDatasetConfig
+from invoke_training.config.shared.data.dataset_config import HFHubImageCaptionDatasetConfig, ImageDirDatasetConfig
 from invoke_training.training._shared.data.data_loaders.textual_inversion_sd_dataloader import (
     build_textual_inversion_sd_dataloader,
 )
@@ -42,3 +42,25 @@ def test_build_textual_inversion_sd_dataloader(image_dir):  # noqa: F811
     crop_top_left_yx = example["crop_top_left_yx"]
     assert len(crop_top_left_yx) == 2
     assert len(crop_top_left_yx[0]) == 2
+
+
+def test_build_textual_inversion_sd_dataloader_keep_original_captions():
+    """Test the keep_original_captions=True option."""
+    config = TextualInversionSDDataLoaderConfig(
+        dataset=HFHubImageCaptionDatasetConfig(dataset_name="lambdalabs/pokemon-blip-captions"),
+        caption_templates=["{}"],
+        keep_original_captions=True,
+    )
+
+    data_loader = build_textual_inversion_sd_dataloader(
+        config=config,
+        placeholder_token="placeholder",
+        batch_size=2,
+    )
+
+    example = next(iter(data_loader))
+    assert set(example.keys()) == {"image", "id", "caption", "original_size_hw", "crop_top_left_yx"}
+
+    assert len(example["caption"]) == 2
+    for caption in example["caption"]:
+        assert caption.startswith("placeholder ")

--- a/tests/invoke_training/training/_shared/data/transforms/test_concat_fields_transform.py
+++ b/tests/invoke_training/training/_shared/data/transforms/test_concat_fields_transform.py
@@ -1,0 +1,11 @@
+from invoke_training.training._shared.data.transforms.concat_fields_transform import ConcatFieldsTransform
+
+
+def test_caption_prefix_transform():
+    tf = ConcatFieldsTransform(src_field_names=["caption", "caption_2"], dst_field_name="caption", separator=", ")
+
+    in_example = {"caption": "original caption", "caption_2": "another caption", "other": 2}
+
+    out_example = tf(in_example)
+
+    assert out_example == {"caption": "original caption, another caption", "caption_2": "another caption", "other": 2}


### PR DESCRIPTION
This replaces the old `apply_caption_prefix`. It can be used to achieve the same effect as `apply_caption_prefix`, but also enables new operating modes.