### PR TITLE
Add more features to the LoRA and TI pipeline

### DIFF
--- a/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
@@ -46,11 +46,22 @@ class LoraAndTiTrainingConfig(BasePipelineConfig):
     exist in the tokenizer's vocabulary.
     """
 
-    initializer_token: str
+    initializer_token: str | None = None
     """A vocabulary token to use as an initializer for the placeholder token. It should be a single word that roughly
     describes the object or style that you're trying to train on. Must map to a single tokenizer token.
 
     For example, if you are training on a dataset of images of your pet dog, a good choice would be `dog`.
+    """
+
+    initial_phrase: str | None = None
+    """Note: Exactly one of `initializer_token` or `initial_phrase` should be set.
+
+    A phrase that will be used to initialize the placeholder token embedding. The phrase will be tokenized, and the
+    corresponding embeddings will be used to initialize the placeholder tokens. The number of embedding vectors will be
+    inferred from the length of the tokenized phrase, so keep the phrase short. The consequences of training a large
+    number of embedding vectors are discussed in the `num_vectors` field documentation.
+
+    For example, if you are training on a dataset of images of pokemon, you might use `pokemon sketch white background`.
     """
 
     train_unet: bool = True

--- a/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
@@ -64,6 +64,14 @@ class LoraAndTiTrainingConfig(BasePipelineConfig):
     train_ti: bool = True
     """Whether to train the textual inversion embeddings."""
 
+    ti_train_steps_ratio: float | None = None
+    """The fraction of the total training steps for which the TI embeddings will be trained. For example, if we are
+    training for a total of 5000 steps and `ti_train_steps_ratio=0.5`, then the TI embeddings will be trained for 2500
+    steps and the will be frozen for the remaining steps.
+
+    If `None`, then the TI embeddings will be trained for the entire duration of training.
+    """
+
     optimizer: AdamOptimizerConfig | ProdigyOptimizerConfig = AdamOptimizerConfig()
 
     text_encoder_learning_rate: float = 1e-5

--- a/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
+++ b/src/invoke_training/training/_experimental/dpo/diffusion_dpo_lora_sd.py
@@ -194,7 +194,7 @@ def run_training(config: DirectPreferenceOptimizationLoRASDConfig):  # noqa: C90
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -226,7 +226,7 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:

--- a/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/textual_inversion_sd.py
@@ -129,7 +129,7 @@ def run_training(config: TextualInversionSDConfig):  # noqa: C901
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_and_ti_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_and_ti_sdxl.py
@@ -130,7 +130,7 @@ def run_training(config: FinetuneLoraAndTiSdxlConfig):  # noqa: C901
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/finetune_lora_sdxl.py
@@ -294,7 +294,7 @@ def run_training(config: FinetuneLoRASDXLConfig):  # noqa: C901
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:

--- a/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion_xl/textual_inversion_sdxl.py
@@ -151,7 +151,7 @@ def run_training(config: TextualInversionSDXLConfig):  # noqa: C901
     accelerator = initialize_accelerator(
         out_dir, config.gradient_accumulation_steps, config.mixed_precision, config.report_to
     )
-    logger = initialize_logging(__name__, accelerator)
+    logger = initialize_logging(os.path.basename(__file__), accelerator)
 
     # Set the accelerate seed.
     if config.seed is not None:


### PR DESCRIPTION
Add `ti_train_steps_ratio` and `initial_phrase` configs to the LoRA and TI pipeline.

(minor) Reduce the length of the prefix on each log line.