### PR TITLE
Default to saving LoRA checkpoints in Kohya format

### DIFF
--- a/docs/get_started/quick_start.md
+++ b/docs/get_started/quick_start.md
@@ -27,25 +27,15 @@ Monitor the training process with Tensorboard by running `tensorboard --logdir o
 ![Screenshot of the Tensorboard UI showing validation images.](../images/tensorboard_val_images_screenshot.png)
 *Validation images in the Tensorboard UI.*
 
-### 5. Select a checkpoint
+### 5. Invokeai
 Select a checkpoint based on the quality of the generated images. In this short training run, there are only 3 checkpoints to choose from. As an example, we'll use the **Epoch 2** checkpoint.
-
-Internally, `invoke-training` stores the LoRA checkpoints in [PEFT format](https://huggingface.co/docs/peft/v0.7.1/en/package_reference/peft_model#peft.PeftModel.save_pretrained). We will convert the selected checkpoint to 'Kohya' format, because it has more widespread support across various UIs:
-```bash
-# Note: You will have to replace the timestamp in the checkpoint path.
-python src/invoke_training/scripts/convert_sd_lora_to_kohya_format.py \
-  --src-ckpt-dir output/finetune_lora_sd_pokemon/1691088769.5694647/checkpoint_epoch-00000002 \
-  --dst-ckpt-file output/finetune_lora_sd_pokemon/1691088769.5694647/checkpoint_epoch-00000002_kohya.safetensors
-```
-
-### 5. InvokeAI
 
 If you haven't already, setup [InvokeAI](https://github.com/invoke-ai/InvokeAI) by following its documentation.
 
 Copy your selected LoRA checkpoint into your `${INVOKEAI_ROOT}/autoimport/lora` directory. For example:
 ```bash
 # Note: You will have to replace the timestamp in the checkpoint path.
-cp output/finetune_lora_sd_pokemon/1691088769.5694647/checkpoint_epoch-00000002_kohya.safetensors ${INVOKEAI_ROOT}/autoimport/lora/pokemon_epoch-00000002.safetensors
+cp output/1691088769.5694647/checkpoint_epoch-00000002.safetensors ${INVOKEAI_ROOT}/autoimport/lora/pokemon_epoch-00000002.safetensors
 ```
 
 You can now use your trained Pokemon LoRA in the InvokeAI UI! 🎉

--- a/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_and_ti_config.py
@@ -23,6 +23,9 @@ class LoraAndTiTrainingConfig(BasePipelineConfig):
     """The Hugging Face Hub model variant to use. Only applies if `model` is a Hugging Face Hub model name.
     """
 
+    lora_checkpoint_format: Literal["invoke_peft", "kohya"] = "kohya"
+    """The format of the LoRA checkpoint to save. Choose between `invoke_peft` or `kohya`."""
+
     # Helpful discussion for understanding how this works at inference time:
     # https://github.com/huggingface/diffusers/pull/3144#discussion_r1172413509
     num_vectors: int = 1

--- a/src/invoke_training/config/pipelines/finetune_lora_config.py
+++ b/src/invoke_training/config/pipelines/finetune_lora_config.py
@@ -44,6 +44,9 @@ class LoRATrainingConfig(BasePipelineConfig):
     generation time with the resultant LoRA model.
     """
 
+    lora_checkpoint_format: Literal["invoke_peft", "kohya"] = "kohya"
+    """The format of the LoRA checkpoint to save. Choose between `invoke_peft` or `kohya`."""
+
     train_unet: bool = True
     """Whether to add LoRA layers to the UNet model and train it.
     """

--- a/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import peft
@@ -35,6 +36,24 @@ SD_PEFT_TEXT_ENCODER_KEY = "text_encoder"
 SDXL_PEFT_UNET_KEY = "unet"
 SDXL_PEFT_TEXT_ENCODER_1_KEY = "text_encoder_1"
 SDXL_PEFT_TEXT_ENCODER_2_KEY = "text_encoder_2"
+
+SD_KOHYA_UNET_KEY = "lora_unet"
+SD_KOHYA_TEXT_ENCODER_KEY = "lora_te"
+
+SDXL_KOHYA_UNET_KEY = "lora_unet"
+SDXL_KOHYA_TEXT_ENCODER_1_KEY = "lora_te1"
+SDXL_KOHYA_TEXT_ENCODER_2_KEY = "lora_te2"
+
+SD_PEFT_TO_KOHYA_KEYS = {
+    SD_PEFT_UNET_KEY: SD_KOHYA_UNET_KEY,
+    SD_PEFT_TEXT_ENCODER_KEY: SD_KOHYA_TEXT_ENCODER_KEY,
+}
+
+SDXL_PEFT_TO_KOHYA_KEYS = {
+    SDXL_PEFT_UNET_KEY: SDXL_KOHYA_UNET_KEY,
+    SDXL_PEFT_TEXT_ENCODER_1_KEY: SDXL_KOHYA_TEXT_ENCODER_1_KEY,
+    SDXL_PEFT_TEXT_ENCODER_2_KEY: SDXL_KOHYA_TEXT_ENCODER_2_KEY,
+}
 
 
 def save_multi_model_peft_checkpoint(checkpoint_dir: Path | str, models: dict[str, peft.PeftModel]):
@@ -177,27 +196,35 @@ def convert_sd_peft_checkpoint_to_kohya_state_dict(
     out_checkpoint_file: Path,
     dtype: torch.dtype = torch.float32,
 ) -> dict[str, torch.Tensor]:
-    """Convert SD v1 PEFT models to a Kohya-format LoRA state dict."""
+    """Convert SD v1 or SDXL PEFT models to a Kohya-format LoRA state dict."""
+    # Get the immediate subdirectories of the checkpoint directory. We assume that each subdirectory is a PEFT model.
+    peft_model_dirs = os.listdir(in_checkpoint_dir)
+    peft_model_dirs = [in_checkpoint_dir / d for d in peft_model_dirs]  # Convert to Path objects.
+    peft_model_dirs = [d for d in peft_model_dirs if d.is_dir()]  # Filter out non-directories.
 
-    if not in_checkpoint_dir.exists():
-        raise ValueError(f"'{in_checkpoint_dir}' does not exist.")
+    if len(peft_model_dirs) == 0:
+        raise ValueError(f"No checkpoint files found in directory '{in_checkpoint_dir}'.")
 
     kohya_state_dict = {}
-    for kohya_prefix, peft_model_key in [("lora_unet", SD_PEFT_UNET_KEY), ("lora_te", SD_PEFT_TEXT_ENCODER_KEY)]:
-        peft_model_dir = in_checkpoint_dir / peft_model_key
+    for peft_model_dir in peft_model_dirs:
+        if peft_model_dir.name in SD_PEFT_TO_KOHYA_KEYS:
+            kohya_prefix = SD_PEFT_TO_KOHYA_KEYS[peft_model_dir.name]
+        elif peft_model_dir.name in SDXL_PEFT_TO_KOHYA_KEYS:
+            kohya_prefix = SDXL_PEFT_TO_KOHYA_KEYS[peft_model_dir.name]
+        else:
+            raise ValueError(f"Unrecognized checkpoint directory: '{peft_model_dir}'.")
 
-        if peft_model_dir.exists():
-            # Note: This logic to load the LoraConfig and weights directly is based on how it is done here:
-            # https://github.com/huggingface/peft/blob/8665e2b5719faa4e4b91749ddec09442927b53e0/src/peft/peft_model.py#L672-L689
-            # This may need to be updated in the future to support other adapter types (LoKr, LoHa, etc.).
-            # Also, I could see this interface breaking in the future.
-            lora_config = peft.LoraConfig.from_pretrained(peft_model_dir)
-            lora_weights = peft.utils.load_peft_weights(peft_model_dir, device="cpu")
+        # Note: This logic to load the LoraConfig and weights directly is based on how it is done here:
+        # https://github.com/huggingface/peft/blob/8665e2b5719faa4e4b91749ddec09442927b53e0/src/peft/peft_model.py#L672-L689
+        # This may need to be updated in the future to support other adapter types (LoKr, LoHa, etc.).
+        # Also, I could see this interface breaking in the future.
+        lora_config = peft.LoraConfig.from_pretrained(peft_model_dir)
+        lora_weights = peft.utils.load_peft_weights(peft_model_dir, device="cpu")
 
-            kohya_state_dict.update(
-                _convert_peft_state_dict_to_kohya_state_dict(
-                    lora_config=lora_config, peft_state_dict=lora_weights, prefix=kohya_prefix, dtype=dtype
-                )
+        kohya_state_dict.update(
+            _convert_peft_state_dict_to_kohya_state_dict(
+                lora_config=lora_config, peft_state_dict=lora_weights, prefix=kohya_prefix, dtype=dtype
             )
+        )
 
     save_state_dict(kohya_state_dict, out_checkpoint_file)

--- a/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
+++ b/src/invoke_training/training/_shared/stable_diffusion/lora_checkpoint_utils.py
@@ -178,6 +178,10 @@ def convert_sd_peft_checkpoint_to_kohya_state_dict(
     dtype: torch.dtype = torch.float32,
 ) -> dict[str, torch.Tensor]:
     """Convert SD v1 PEFT models to a Kohya-format LoRA state dict."""
+
+    if not in_checkpoint_dir.exists():
+        raise ValueError(f"'{in_checkpoint_dir}' does not exist.")
+
     kohya_state_dict = {}
     for kohya_prefix, peft_model_key in [("lora_unet", SD_PEFT_UNET_KEY), ("lora_te", SD_PEFT_TEXT_ENCODER_KEY)]:
         peft_model_dir = in_checkpoint_dir / peft_model_key

--- a/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
+++ b/src/invoke_training/training/pipelines/stable_diffusion/finetune_lora_sd.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import peft
 import torch
@@ -39,6 +39,7 @@ from invoke_training.training._shared.optimizer.optimizer_utils import initializ
 from invoke_training.training._shared.stable_diffusion.lora_checkpoint_utils import (
     TEXT_ENCODER_TARGET_MODULES,
     UNET_TARGET_MODULES,
+    save_sd_kohya_checkpoint,
     save_sd_peft_checkpoint,
 )
 from invoke_training.training._shared.stable_diffusion.model_loading_utils import load_models_sd
@@ -52,6 +53,7 @@ def _save_sd_lora_checkpoint(
     text_encoder: peft.PeftModel | None,
     logger: logging.Logger,
     checkpoint_tracker: CheckpointTracker,
+    lora_checkpoint_format: Literal["invoke_peft", "kohya"],
 ):
     # Prune checkpoints and get new checkpoint path.
     num_pruned = checkpoint_tracker.prune(1)
@@ -59,7 +61,12 @@ def _save_sd_lora_checkpoint(
         logger.info(f"Pruned {num_pruned} checkpoint(s).")
     save_path = checkpoint_tracker.get_path(idx)
 
-    save_sd_peft_checkpoint(Path(save_path), unet=unet, text_encoder=text_encoder)
+    if lora_checkpoint_format == "invoke_peft":
+        save_sd_peft_checkpoint(Path(save_path), unet=unet, text_encoder=text_encoder)
+    elif lora_checkpoint_format == "kohya":
+        save_sd_kohya_checkpoint(Path(save_path), unet=unet, text_encoder=text_encoder)
+    else:
+        raise ValueError(f"Unsupported lora_checkpoint_format: '{lora_checkpoint_format}'.")
 
 
 def _build_data_loader(
@@ -437,12 +444,14 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
         base_dir=ckpt_dir,
         prefix="checkpoint_epoch",
         max_checkpoints=config.max_checkpoints,
+        extension=".safetensors" if config.lora_checkpoint_format == "kohya" else None,
     )
 
     step_checkpoint_tracker = CheckpointTracker(
         base_dir=ckpt_dir,
         prefix="checkpoint_step",
         max_checkpoints=config.max_checkpoints,
+        extension=".safetensors" if config.lora_checkpoint_format == "kohya" else None,
     )
 
     # Train!
@@ -524,6 +533,7 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
                             text_encoder=accelerator.unwrap_model(text_encoder) if config.train_text_encoder else None,
                             logger=logger,
                             checkpoint_tracker=step_checkpoint_tracker,
+                            lora_checkpoint_format=config.lora_checkpoint_format,
                         )
 
             logs = {
@@ -545,6 +555,7 @@ def run_training(config: FinetuneLoRASDConfig):  # noqa: C901
                     text_encoder=accelerator.unwrap_model(text_encoder) if config.train_text_encoder else None,
                     logger=logger,
                     checkpoint_tracker=epoch_checkpoint_tracker,
+                    lora_checkpoint_format=config.lora_checkpoint_format,
                 )
 
         # Generate validation images every n epochs.

--- a/tests/invoke_training/training/_shared/stable_diffusion/test_lora_checkpoint_utils.py
+++ b/tests/invoke_training/training/_shared/stable_diffusion/test_lora_checkpoint_utils.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from invoke_training.training._shared.stable_diffusion.lora_checkpoint_utils import (
+    convert_sd_peft_checkpoint_to_kohya_state_dict,
+)
+
+
+def test_convert_sd_peft_checkpoint_to_kohya_state_dict_raise_on_empty_directory(tmp_path: Path):
+    with pytest.raises(ValueError, match="No checkpoint files found in directory"):
+        convert_sd_peft_checkpoint_to_kohya_state_dict(
+            in_checkpoint_dir=tmp_path, out_checkpoint_file=tmp_path / "out.safetensors"
+        )
+
+
+def test_convert_sd_peft_checkpoint_to_kohya_state_dict_raise_on_unexpected_subdirectory(tmp_path: Path):
+    subdirectory = tmp_path / "subdir"
+    subdirectory.mkdir()
+
+    with pytest.raises(ValueError, match=f"Unrecognized checkpoint directory: '{subdirectory}'."):
+        convert_sd_peft_checkpoint_to_kohya_state_dict(
+            in_checkpoint_dir=tmp_path, out_checkpoint_file=tmp_path / "out.safetensors"
+        )


### PR DESCRIPTION
Default to saving LoRA checkpoints in Kohya format. Added the `lora_checkpoint_format` config params to control this.