### PR TITLE
Add support for ImageCaptionDirDataset

### DIFF
--- a/docs/concepts/dataset_formats.md
+++ b/docs/concepts/dataset_formats.md
@@ -1,20 +1,32 @@
-# Image Caption Dataset Formats
-Many of the `invoke-training` training methods require datasets consisting of image-caption pairs. This document explains the supported dataset formats, and how they can be prepared.
+# Dataset Formats
 
-`invoke-training` uses [Hugging Face Datasets](https://huggingface.co/docs/datasets/main/en/index) to handle datasets. Image caption datasets can either be downloaded from the [Hugging Face Hub](https://huggingface.co/datasets), or loaded from a directory using the [ImageFolder](https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder) format. More details are included in the following sections.
+`invoke-training` supports the following dataset formats:
 
-### Hugging Face Hub Datasets
+- `HF_HUB_IMAGE_CAPTION_DATASET`: A Hugging Face Hub dataset containing images and captions.
+- `IMAGE_CAPTION_JSONL_DATASET`: A local image-caption dataset described by a single `.jsonl` file.
+- `IMAGE_CAPTION_DIR_DATASET`: A local directory of images with associated `.txt` caption files.
+- `IMAGE_DIR_DATASET`: A local directory of images (without captions).
+
+See the documentation for a particular training pipeline to see which dataset formats it supports.
+
+The following sections explain each of these formats in more detail.
+
+## `HF_HUB_IMAGE_CAPTION_DATASET`
+
+Config documentation: [HFHubImageCaptionDatasetConfig][invoke_training.config.data.dataset_config.HFHubImageCaptionDatasetConfig]
+
 The easiest way to get started with `invoke-training` is to use a publicly available dataset on [Hugging Face Hub](https://huggingface.co/datasets). You can filter for the `Text-to-Image` task to find relevant datasets that contain both an image column and a caption column. [lambdalabs/pokemon-blip-captions](https://huggingface.co/datasets/lambdalabs/pokemon-blip-captions) is a popular choice if you're not sure where to start.
 
-Once you've selected a dataset from the Hugging Face Hub, you can use it with any pipeline that supports the [HFDirImageCaptionDatasetConfig][invoke_training.config.data.dataset_config.HFDirImageCaptionDatasetConfig] type.
+## `IMAGE_CAPTION_JSONL_DATASET`
 
-### ImageFolder Datasets
-If you want to create custom datasets, then you will most likely want to use the [ImageFolder](https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder) dataset format.
+Config documentation: [ImageCaptionJsonlDatasetConfig][invoke_training.config.data.dataset_config.ImageCaptionJsonlDatasetConfig]
 
-An `ImageFolder` dataset should have the following directory structure:
+A `IMAGE_CAPTION_JSONL_DATASET` consists of a single `.jsonl` file containing image paths and associated captions.
+
+Sample directory structure:
 ```bash
 my_custom_dataset/
-├── metadata.jsonl
+├── data.jsonl
 └── train/
     ├── 0001.png
     ├── 0002.png
@@ -22,11 +34,71 @@ my_custom_dataset/
     └── ...
 ```
 
-The contents of `metadata.jsonl` should be:
+The contents of `data.jsonl` would be:
 ```json
 {"file_name": "train/0001.png", "text": "This is a caption describing image 0001."}
 {"file_name": "train/0002.png", "text": "This is a caption describing image 0002."}
 {"file_name": "train/0003.png", "text": "This is a caption describing image 0003."}
 ```
 
-To use a custom `ImageFolder` dataset in training, use a [HFDirImageCaptionDatasetConfig][invoke_training.config.data.dataset_config.HFDirImageCaptionDatasetConfig] dataset type.
+The image file paths can be either absolute paths, or relative to the `.jsonl` file.
+
+Finally, this dataset can be used with the following pipeline dataset configuration:
+```yaml
+type: IMAGE_CAPTION_JSONL_DATASET
+jsonl_path: /path/to/my_custom_dataset/metadata.jsonl
+image_column: file_name
+caption_column: text
+```
+
+A useful characteristic of this dataset format is that a `.jsonl` file can reference an image file anywhere on the local disk. It is common to maintain multiple `.jsonl` datasets that reference some of the same images without needing multiple copies of those images on disk.
+
+## `IMAGE_CAPTION_DIR_DATASET`
+
+Config documentation: [ImageCaptionDirDataset][invoke_training.config.data.dataset_config.ImageCaptionDirDatasetConfig]
+
+A `IMAGE_CAPTION_DIR_DATASET` consists of a directory of image files and corresponding `.txt` caption files of the same name.
+
+Sample directory structure:
+```bash
+my_custom_dataset/
+├── 0001.png
+├── 0001.txt
+├── 0002.jpg
+├── 0002.txt
+├── 0003.png
+├── 0003.txt
+└── ...
+```
+
+Each `.txt` file should contain a caption on the first line of the file. Here are the sample contents of `0001.txt`:
+```txt title="0001.txt"
+this is a caption for example 0001
+```
+
+This dataset can be used with the following pipeline dataset configuration:
+```yaml
+type: IMAGE_CAPTION_DIR_DATASET
+dataset_dir: /path/to/my_custom_dataset
+```
+
+## `IMAGE_DIR_DATASET`
+
+Config documentation: [ImageDirDataset][invoke_training.config.data.dataset_config.ImageDirDatasetConfig]
+
+A `IMAGE_DIR_DATASET` consists of a single directory of images (without captions).
+
+Sample directory structure:
+```bash
+my_custom_dataset/
+├── 0001.png
+├── 0002.jpg
+├── 0003.png
+└── ...
+```
+
+This dataset can be used with the following pipeline dataset configuration:
+```yaml
+type: IMAGE_DIR_DATASET
+dataset_dir: /path/to/my_custom_dataset
+```

--- a/src/invoke_training/_shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/_shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -4,9 +4,9 @@ import torch
 from torch.utils.data import DataLoader
 
 from invoke_training._shared.data.datasets.build_dataset import (
-    build_hf_dir_image_caption_dataset,
     build_hf_hub_image_caption_dataset,
     build_image_caption_dir_dataset,
+    build_image_caption_jsonl_dataset,
 )
 from invoke_training._shared.data.datasets.transform_dataset import TransformDataset
 from invoke_training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import (
@@ -23,9 +23,9 @@ from invoke_training.config.data.data_loader_config import (
     ImageCaptionSDDataLoaderConfig,
 )
 from invoke_training.config.data.dataset_config import (
-    HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
     ImageCaptionDirDatasetConfig,
+    ImageCaptionJsonlDatasetConfig,
 )
 
 
@@ -95,8 +95,8 @@ def build_image_caption_sd_dataloader(
     """
     if isinstance(config.dataset, HFHubImageCaptionDatasetConfig):
         base_dataset = build_hf_hub_image_caption_dataset(config.dataset)
-    elif isinstance(config.dataset, HFDirImageCaptionDatasetConfig):
-        base_dataset = build_hf_dir_image_caption_dataset(config.dataset)
+    elif isinstance(config.dataset, ImageCaptionJsonlDatasetConfig):
+        base_dataset = build_image_caption_jsonl_dataset(config.dataset)
     elif isinstance(config.dataset, ImageCaptionDirDatasetConfig):
         base_dataset = build_image_caption_dir_dataset(config.dataset)
     else:

--- a/src/invoke_training/_shared/data/data_loaders/image_caption_sd_dataloader.py
+++ b/src/invoke_training/_shared/data/data_loaders/image_caption_sd_dataloader.py
@@ -6,6 +6,7 @@ from torch.utils.data import DataLoader
 from invoke_training._shared.data.datasets.build_dataset import (
     build_hf_dir_image_caption_dataset,
     build_hf_hub_image_caption_dataset,
+    build_image_caption_dir_dataset,
 )
 from invoke_training._shared.data.datasets.transform_dataset import TransformDataset
 from invoke_training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import (
@@ -24,6 +25,7 @@ from invoke_training.config.data.data_loader_config import (
 from invoke_training.config.data.dataset_config import (
     HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
+    ImageCaptionDirDatasetConfig,
 )
 
 
@@ -95,6 +97,8 @@ def build_image_caption_sd_dataloader(
         base_dataset = build_hf_hub_image_caption_dataset(config.dataset)
     elif isinstance(config.dataset, HFDirImageCaptionDatasetConfig):
         base_dataset = build_hf_dir_image_caption_dataset(config.dataset)
+    elif isinstance(config.dataset, ImageCaptionDirDatasetConfig):
+        base_dataset = build_image_caption_dir_dataset(config.dataset)
     else:
         raise ValueError(f"Unexpected dataset config type: '{type(config.dataset)}'.")
 

--- a/src/invoke_training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
+++ b/src/invoke_training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
@@ -9,6 +9,7 @@ from invoke_training._shared.data.data_loaders.image_caption_sd_dataloader impor
 from invoke_training._shared.data.datasets.build_dataset import (
     build_hf_dir_image_caption_dataset,
     build_hf_hub_image_caption_dataset,
+    build_image_caption_dir_dataset,
 )
 from invoke_training._shared.data.datasets.image_dir_dataset import ImageDirDataset
 from invoke_training._shared.data.datasets.transform_dataset import TransformDataset
@@ -28,6 +29,7 @@ from invoke_training.config.data.data_loader_config import TextualInversionSDDat
 from invoke_training.config.data.dataset_config import (
     HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
+    ImageCaptionDirDatasetConfig,
     ImageDirDatasetConfig,
 )
 
@@ -119,6 +121,8 @@ def build_textual_inversion_sd_dataloader(  # noqa: C901
         base_dataset = build_hf_hub_image_caption_dataset(config.dataset)
     elif isinstance(config.dataset, HFDirImageCaptionDatasetConfig):
         base_dataset = build_hf_dir_image_caption_dataset(config.dataset)
+    elif isinstance(config.dataset, ImageCaptionDirDatasetConfig):
+        base_dataset = build_image_caption_dir_dataset(config.dataset)
     elif isinstance(config.dataset, ImageDirDatasetConfig):
         base_dataset = ImageDirDataset(
             image_dir=config.dataset.dataset_dir, keep_in_memory=config.dataset.keep_in_memory

--- a/src/invoke_training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
+++ b/src/invoke_training/_shared/data/data_loaders/textual_inversion_sd_dataloader.py
@@ -7,9 +7,9 @@ from invoke_training._shared.data.data_loaders.image_caption_sd_dataloader impor
     sd_image_caption_collate_fn,
 )
 from invoke_training._shared.data.datasets.build_dataset import (
-    build_hf_dir_image_caption_dataset,
     build_hf_hub_image_caption_dataset,
     build_image_caption_dir_dataset,
+    build_image_caption_jsonl_dataset,
 )
 from invoke_training._shared.data.datasets.image_dir_dataset import ImageDirDataset
 from invoke_training._shared.data.datasets.transform_dataset import TransformDataset
@@ -27,9 +27,9 @@ from invoke_training._shared.data.transforms.template_caption_transform import (
 from invoke_training._shared.data.transforms.tensor_disk_cache import TensorDiskCache
 from invoke_training.config.data.data_loader_config import TextualInversionSDDataLoaderConfig
 from invoke_training.config.data.dataset_config import (
-    HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
     ImageCaptionDirDatasetConfig,
+    ImageCaptionJsonlDatasetConfig,
     ImageDirDatasetConfig,
 )
 
@@ -119,8 +119,8 @@ def build_textual_inversion_sd_dataloader(  # noqa: C901
     """
     if isinstance(config.dataset, HFHubImageCaptionDatasetConfig):
         base_dataset = build_hf_hub_image_caption_dataset(config.dataset)
-    elif isinstance(config.dataset, HFDirImageCaptionDatasetConfig):
-        base_dataset = build_hf_dir_image_caption_dataset(config.dataset)
+    elif isinstance(config.dataset, ImageCaptionJsonlDatasetConfig):
+        base_dataset = build_image_caption_jsonl_dataset(config.dataset)
     elif isinstance(config.dataset, ImageCaptionDirDatasetConfig):
         base_dataset = build_image_caption_dir_dataset(config.dataset)
     elif isinstance(config.dataset, ImageDirDatasetConfig):

--- a/src/invoke_training/_shared/data/datasets/build_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/build_dataset.py
@@ -2,9 +2,11 @@ from datasets import VerificationMode
 
 from invoke_training._shared.data.datasets.hf_image_caption_dataset import HFImageCaptionDataset
 from invoke_training._shared.data.datasets.hf_image_pair_preference_dataset import HFImagePairPreferenceDataset
+from invoke_training._shared.data.datasets.image_caption_dir_dataset import ImageCaptionDirDataset
 from invoke_training.config.data.dataset_config import (
     HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
+    ImageCaptionDirDatasetConfig,
 )
 from invoke_training.pipelines._experimental.sd_dpo_lora.config import HFHubImagePairPreferenceDatasetConfig
 
@@ -27,6 +29,13 @@ def build_hf_dir_image_caption_dataset(config: HFDirImageCaptionDatasetConfig) -
         hf_load_dataset_kwargs=None,
         image_column=config.image_column,
         caption_column=config.caption_column,
+    )
+
+
+def build_image_caption_dir_dataset(config: ImageCaptionDirDatasetConfig) -> ImageCaptionDirDataset:
+    return ImageCaptionDirDataset(
+        dataset_dir=config.dataset_dir,
+        keep_in_memory=config.keep_in_memory,
     )
 
 

--- a/src/invoke_training/_shared/data/datasets/build_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/build_dataset.py
@@ -3,10 +3,11 @@ from datasets import VerificationMode
 from invoke_training._shared.data.datasets.hf_image_caption_dataset import HFImageCaptionDataset
 from invoke_training._shared.data.datasets.hf_image_pair_preference_dataset import HFImagePairPreferenceDataset
 from invoke_training._shared.data.datasets.image_caption_dir_dataset import ImageCaptionDirDataset
+from invoke_training._shared.data.datasets.image_caption_jsonl_dataset import ImageCaptionJsonlDataset
 from invoke_training.config.data.dataset_config import (
-    HFDirImageCaptionDatasetConfig,
     HFHubImageCaptionDatasetConfig,
     ImageCaptionDirDatasetConfig,
+    ImageCaptionJsonlDatasetConfig,
 )
 from invoke_training.pipelines._experimental.sd_dpo_lora.config import HFHubImagePairPreferenceDatasetConfig
 
@@ -23,12 +24,9 @@ def build_hf_hub_image_caption_dataset(config: HFHubImageCaptionDatasetConfig) -
     )
 
 
-def build_hf_dir_image_caption_dataset(config: HFDirImageCaptionDatasetConfig) -> HFImageCaptionDataset:
-    return HFImageCaptionDataset.from_dir(
-        dataset_dir=config.dataset_dir,
-        hf_load_dataset_kwargs=None,
-        image_column=config.image_column,
-        caption_column=config.caption_column,
+def build_image_caption_jsonl_dataset(config: ImageCaptionJsonlDatasetConfig) -> HFImageCaptionDataset:
+    return ImageCaptionJsonlDataset(
+        jsonl_path=config.jsonl_path, image_column=config.image_column, caption_column=config.caption_column
     )
 
 

--- a/src/invoke_training/_shared/data/datasets/image_caption_dir_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/image_caption_dir_dataset.py
@@ -1,0 +1,88 @@
+import os
+import typing
+
+import torch.utils.data
+from PIL import Image
+
+from invoke_training._shared.data.utils.resolution import Resolution
+
+
+class ImageCaptionDirDataset(torch.utils.data.Dataset):
+    """A dataset that loads images and captions from a directory of image files and .txt files."""
+
+    def __init__(
+        self,
+        dataset_dir: str,
+        id_prefix: str = "",
+        image_extensions: typing.Optional[list[str]] = None,
+        caption_extension: str = ".txt",
+        keep_in_memory: bool = False,
+    ):
+        """Initialize an ImageDirDataset
+
+        Args:
+            image_dir (str): The directory to load images from.
+            id_prefix (str): A prefix added to the 'id' field in every example.
+            image_extensions (list[str], optional): The list of image file extensions to include in the dataset (not
+                case-sensitive). Defaults to [".jpg", ".jpeg", ".png"].
+            keep_in_memory (bool, optional): If True, keep all images loaded in memory. This improves performance for
+                datasets that are small enough to be kept in memory.
+        """
+        super().__init__()
+        self._id_prefix = id_prefix
+        if image_extensions is None:
+            image_extensions = [".jpg", ".jpeg", ".png"]
+        image_extensions = [ext.lower() for ext in image_extensions]
+
+        # Determine the list of image paths to include in the dataset.
+        self._image_paths: list[str] = []
+        for image_file in os.listdir(dataset_dir):
+            image_path = os.path.join(dataset_dir, image_file)
+            if os.path.isfile(image_path) and os.path.splitext(image_path)[1].lower() in image_extensions:
+                self._image_paths.append(image_path)
+        self._image_paths.sort()
+
+        # Load captions from .txt files for each image.
+        self._captions: list[str] = []
+        missing_captions: list[str] = []
+        for image_path in self._image_paths:
+            caption_path = os.path.splitext(image_path)[0] + caption_extension
+            if os.path.isfile(caption_path):
+                with open(caption_path, "r") as f:
+                    self._captions.append(f.read().strip())
+            else:
+                missing_captions.append(caption_path)
+        if len(missing_captions) > 0:
+            raise Exception(f"The following expected caption files are missing: {missing_captions}")
+
+        self._images = None
+        if keep_in_memory:
+            self._images = []
+            for image_path in self._image_paths:
+                self._images.append(self._load_image(image_path))
+
+    def _load_image(self, image_path: str) -> Image.Image:
+        # We call `convert("RGB")` to drop the alpha channel from RGBA images, or to repeat channels for greyscale
+        # images.
+        return Image.open(image_path).convert("RGB")
+
+    def get_image_dimensions(self) -> list[Resolution]:
+        """Get the dimensions of all images in the dataset.
+
+        TODO(ryand): Re-think this approach. For large datasets (e.g. streaming from S3) it doesn't make sense to
+        calculate this dynamically every time.
+        """
+        image_dims: list[Resolution] = []
+        for i in range(len(self._image_paths)):
+            image_path = self._image_paths[i]
+            image = Image.open(image_path)
+            image_dims.append(Resolution(image.height, image.width))
+
+        return image_dims
+
+    def __len__(self) -> int:
+        return len(self._image_paths)
+
+    def __getitem__(self, idx: int) -> typing.Dict[str, typing.Any]:
+        image = self._images[idx] if self._images is not None else self._load_image(self._image_paths[idx])
+        return {"id": f"{self._id_prefix}{idx}", "image": image, "caption": self._captions[idx]}

--- a/src/invoke_training/_shared/data/datasets/image_caption_jsonl_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/image_caption_jsonl_dataset.py
@@ -1,0 +1,57 @@
+import json
+import typing
+
+import torch.utils.data
+from PIL import Image
+
+from invoke_training._shared.data.utils.resolution import Resolution
+
+
+class ImageCaptionJsonlDataset(torch.utils.data.Dataset):
+    """A dataset that loads images and captions from a directory of image files and .txt files."""
+
+    def __init__(
+        self,
+        jsonl_path: str,
+        image_column: str = "image",
+        caption_column: str = "text",
+    ):
+        """Initialize an ImageCaptionDirDataset"""
+        super().__init__()
+
+        self._data: list[dict[str, typing.Any]] = []
+        with open(jsonl_path) as f:
+            while (line := f.readline()) != "":
+                line_json = json.loads(line)
+                assert image_column in line_json
+                assert caption_column in line_json
+                self._data.append(line_json)
+
+        self._image_column = image_column
+        self._caption_column = caption_column
+
+    def _load_image(self, image_path: str) -> Image.Image:
+        # We call `convert("RGB")` to drop the alpha channel from RGBA images, or to repeat channels for greyscale
+        # images.
+        return Image.open(image_path).convert("RGB")
+
+    def get_image_dimensions(self) -> list[Resolution]:
+        """Get the dimensions of all images in the dataset.
+
+        TODO(ryand): Re-think this approach. For large datasets (e.g. streaming from S3) it doesn't make sense to
+        calculate this dynamically every time.
+        """
+        image_dims: list[Resolution] = []
+        for i in range(len(self._data)):
+            image_path = self._data[i][self._image_column]
+            image = Image.open(image_path)
+            image_dims.append(Resolution(image.height, image.width))
+
+        return image_dims
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __getitem__(self, idx: int) -> typing.Dict[str, typing.Any]:
+        image = self._load_image(self._data[idx][self._image_column])
+        return {"id": str(idx), "image": image, "caption": self._data[idx][self._caption_column]}

--- a/src/invoke_training/config/data/dataset_config.py
+++ b/src/invoke_training/config/data/dataset_config.py
@@ -30,12 +30,11 @@ class HFHubImageCaptionDatasetConfig(ConfigBaseModel):
     """
 
 
-class HFDirImageCaptionDatasetConfig(ConfigBaseModel):
-    type: Literal["HF_DIR_IMAGE_CAPTION_DATASET"] = "HF_DIR_IMAGE_CAPTION_DATASET"
+class ImageCaptionJsonlDatasetConfig(ConfigBaseModel):
+    type: Literal["IMAGE_CAPTION_JSONL_DATASET"] = "IMAGE_CAPTION_JSONL_DATASET"
 
-    dataset_dir: str
-    """The directory to load a dataset from. The dataset is expected to be in
-    Hugging Face imagefolder format (https://huggingface.co/docs/datasets/v2.4.0/en/image_load#imagefolder)."""
+    jsonl_path: str
+    """The path to a JSONL file containing image paths and captions."""
 
     image_column: str = "image"
     """The name of the dataset column that contains image paths.
@@ -60,7 +59,7 @@ class ImageDirDatasetConfig(ConfigBaseModel):
 
 
 class ImageCaptionDirDatasetConfig(ConfigBaseModel):
-    type: Literal["IMAGE_CAPTION_DIR_DATASET"] = "IMAGE_DIR_DATASET"
+    type: Literal["IMAGE_CAPTION_DIR_DATASET"] = "IMAGE_CAPTION_DIR_DATASET"
 
     dataset_dir: str
     """The directory to load images from."""
@@ -74,6 +73,6 @@ class ImageCaptionDirDatasetConfig(ConfigBaseModel):
 
 # Datasets that produce image-caption pairs.
 ImageCaptionDatasetConfig = Annotated[
-    Union[HFDirImageCaptionDatasetConfig, HFHubImageCaptionDatasetConfig, ImageCaptionDirDatasetConfig],
+    Union[HFHubImageCaptionDatasetConfig, ImageCaptionJsonlDatasetConfig, ImageCaptionDirDatasetConfig],
     Field(discriminator="type"),
 ]

--- a/src/invoke_training/config/data/dataset_config.py
+++ b/src/invoke_training/config/data/dataset_config.py
@@ -59,7 +59,21 @@ class ImageDirDatasetConfig(ConfigBaseModel):
     """
 
 
+class ImageCaptionDirDatasetConfig(ConfigBaseModel):
+    type: Literal["IMAGE_CAPTION_DIR_DATASET"] = "IMAGE_DIR_DATASET"
+
+    dataset_dir: str
+    """The directory to load images from."""
+
+    keep_in_memory: bool = False
+    """If `True`, load all images into memory on initialization so that they can be accessed quickly. If `False`, images
+    are loaded from disk each time they are accessed. Setting to `True` improves performance for datasets that are small
+    enough to be kept in memory.
+    """
+
+
 # Datasets that produce image-caption pairs.
 ImageCaptionDatasetConfig = Annotated[
-    Union[HFDirImageCaptionDatasetConfig, HFHubImageCaptionDatasetConfig], Field(discriminator="type")
+    Union[HFDirImageCaptionDatasetConfig, HFHubImageCaptionDatasetConfig, ImageCaptionDirDatasetConfig],
+    Field(discriminator="type"),
 ]

--- a/tests/invoke_training/_shared/data/datasets/test_image_caption_dir_dataset.py
+++ b/tests/invoke_training/_shared/data/datasets/test_image_caption_dir_dataset.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import PIL.Image
+import pytest
+
+from invoke_training._shared.data.datasets.image_caption_dir_dataset import ImageCaptionDirDataset
+
+from ..image_dir_fixture import image_caption_dir  # noqa: F401
+
+
+def test_image_caption_dir_dataset_len(image_caption_dir):  # noqa: F811
+    dataset = ImageCaptionDirDataset(str(image_caption_dir))
+
+    assert len(dataset) == 5
+
+
+def test_image_caption_dir_dataset_getitem(image_caption_dir):  # noqa: F811
+    dataset = ImageCaptionDirDataset(str(image_caption_dir))
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id", "caption"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == "0"
+    assert example["caption"] == "caption 0"
+
+
+def test_image_caption_dir_dataset_keep_in_memory(image_caption_dir):  # noqa: F811
+    dataset = ImageCaptionDirDataset(str(image_caption_dir), keep_in_memory=True)
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id", "caption"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == "0"
+    assert example["caption"] == "caption 0"
+
+
+def test_image_caption_dir_dataset_get_image_dimensions(image_caption_dir):  # noqa: F811
+    dataset = ImageCaptionDirDataset(str(image_caption_dir))
+
+    image_dims = dataset.get_image_dimensions()
+
+    assert len(image_dims) == len(dataset)
+
+
+def test_image_caption_dir_dataset_missing_caption_file(tmp_path: Path):  # noqa: F811
+    # Create a directory with an image but no caption file.
+    with open(tmp_path / "0.jpg", "w"):
+        pass
+
+    with pytest.raises(Exception, match=r"The following expected caption files are missing: \['.*0.txt'\]"):
+        ImageCaptionDirDataset(str(tmp_path))

--- a/tests/invoke_training/_shared/data/datasets/test_image_caption_jsonl_dataset.py
+++ b/tests/invoke_training/_shared/data/datasets/test_image_caption_jsonl_dataset.py
@@ -1,0 +1,31 @@
+import PIL.Image
+
+from invoke_training._shared.data.datasets.image_caption_jsonl_dataset import ImageCaptionJsonlDataset
+
+from ..image_dir_fixture import image_caption_jsonl  # noqa: F401
+
+
+def test_image_caption_jsonl_dataset_len(image_caption_jsonl):  # noqa: F811
+    dataset = ImageCaptionJsonlDataset(str(image_caption_jsonl))
+
+    assert len(dataset) == 5
+
+
+def test_image_caption_jsonl_dataset_getitem(image_caption_jsonl):  # noqa: F811
+    dataset = ImageCaptionJsonlDataset(str(image_caption_jsonl))
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id", "caption"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == "0"
+    assert example["caption"] == "caption 0"
+
+
+def test_image_caption_jsonl_dataset_get_image_dimensions(image_caption_jsonl):  # noqa: F811
+    dataset = ImageCaptionJsonlDataset(str(image_caption_jsonl))
+
+    image_dims = dataset.get_image_dimensions()
+
+    assert len(image_dims) == len(dataset)

--- a/tests/invoke_training/_shared/data/image_dir_fixture.py
+++ b/tests/invoke_training/_shared/data/image_dir_fixture.py
@@ -67,10 +67,10 @@ def image_caption_jsonl(tmp_path_factory: pytest.TempPathFactory):
     for i in range(5):
         rgb_np = np.ones((128, 128, 3), dtype=np.uint8)
         rgb_pil = PIL.Image.fromarray(rgb_np)
-        rgb_path = tmp_dir / f"{i}.jpg"
-        rgb_pil.save(rgb_path)
+        rgb_rel_path = f"{i}.jpg"
+        rgb_pil.save(tmp_dir / rgb_rel_path)
 
-        data.append({"image": str(rgb_path), "text": f"caption {i}"})
+        data.append({"image": str(rgb_rel_path), "text": f"caption {i}"})
 
     data_jsonl_path = tmp_dir / "data.jsonl"
     with open(data_jsonl_path, "w") as f:

--- a/tests/invoke_training/_shared/data/image_dir_fixture.py
+++ b/tests/invoke_training/_shared/data/image_dir_fixture.py
@@ -26,6 +26,29 @@ def image_dir(tmp_path_factory: pytest.TempPathFactory):
 
 
 @pytest.fixture(scope="session")
+def image_caption_dir(tmp_path_factory: pytest.TempPathFactory):
+    """A fixture that populates a temp directory with some test images and caption files and returns the directory path.
+
+    Note that the 'session' scope is used to share the same directory across all tests in a session, because it is
+    costly to populate the directory.
+
+    Refer to https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#the-tmp-path-factory-fixture for details on the use
+    of tmp_path_factory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("dataset")
+
+    for i in range(5):
+        rgb_np = np.ones((128, 128, 3), dtype=np.uint8)
+        rgb_pil = PIL.Image.fromarray(rgb_np)
+        rgb_pil.save(tmp_dir / f"{i}.jpg")
+
+        with open(tmp_dir / f"{i}.txt", "w") as f:
+            f.write(f"caption {i}")
+
+    return tmp_dir
+
+
+@pytest.fixture(scope="session")
 def image_pair_preference_dir(tmp_path_factory: pytest.TempPathFactory):
     """A fixture that populates a temp directory with a mock dataset intended to be consumed by
     ImagePairPreferenceDataset, and returns the directory path.

--- a/tests/invoke_training/_shared/data/image_dir_fixture.py
+++ b/tests/invoke_training/_shared/data/image_dir_fixture.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 import PIL.Image
 import pytest
@@ -46,6 +48,37 @@ def image_caption_dir(tmp_path_factory: pytest.TempPathFactory):
             f.write(f"caption {i}")
 
     return tmp_dir
+
+
+@pytest.fixture(scope="session")
+def image_caption_jsonl(tmp_path_factory: pytest.TempPathFactory):
+    """A fixture that populates a temp directory with a ImageCaptionJsonlDataset and returns the jsonl file path.
+
+    Note that the 'session' scope is used to share the same directory across all tests in a session, because it is
+    costly to populate the directory.
+
+    Refer to https://docs.pytest.org/en/7.4.x/how-to/tmp_path.html#the-tmp-path-factory-fixture for details on the use
+    of tmp_path_factory.
+    """
+    tmp_dir = tmp_path_factory.mktemp("dataset")
+
+    data = []
+
+    for i in range(5):
+        rgb_np = np.ones((128, 128, 3), dtype=np.uint8)
+        rgb_pil = PIL.Image.fromarray(rgb_np)
+        rgb_path = tmp_dir / f"{i}.jpg"
+        rgb_pil.save(rgb_path)
+
+        data.append({"image": str(rgb_path), "text": f"caption {i}"})
+
+    data_jsonl_path = tmp_dir / "data.jsonl"
+    with open(data_jsonl_path, "w") as f:
+        for d in data:
+            json.dump(d, f)
+            f.write("\n")
+
+    return data_jsonl_path
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
- Add support for a ImageCaptionDirDataset (a dataset consisting of image files and corresponding .txt files.).
- Add a ImageCaptionJsonlDataset format to replace the HF imagefolder format (the imagefolder had too many quirks, it's easier if we just own this format).
- Improve the dataset format documentation.