### PR TITLE
Update SD1.5 TI embedding output format

### DIFF
--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -41,7 +41,6 @@ def _save_ti_embeddings(
     text_encoder: CLIPTextModel,
     placeholder_token_ids: list[int],
     accelerator: Accelerator,
-    placeholder_token: str,
     logger: logging.Logger,
     checkpoint_tracker: CheckpointTracker,
 ):
@@ -59,7 +58,7 @@ def _save_ti_embeddings(
         .get_input_embeddings()
         .weight[min(placeholder_token_ids) : max(placeholder_token_ids) + 1]
     )
-    learned_embeds_dict = {placeholder_token: learned_embeds.detach().cpu()}
+    learned_embeds_dict = {"emb_params": learned_embeds.detach().cpu()}
 
     save_state_dict(learned_embeds_dict, save_path)
 
@@ -366,7 +365,6 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                             text_encoder=text_encoder,
                             placeholder_token_ids=placeholder_token_ids,
                             accelerator=accelerator,
-                            placeholder_token=config.placeholder_token,
                             logger=logger,
                             checkpoint_tracker=step_checkpoint_tracker,
                         )
@@ -406,7 +404,6 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                     text_encoder=text_encoder,
                     placeholder_token_ids=placeholder_token_ids,
                     accelerator=accelerator,
-                    placeholder_token=config.placeholder_token,
                     logger=logger,
                     checkpoint_tracker=epoch_checkpoint_tracker,
                 )


### PR DESCRIPTION
This PR addresses https://github.com/invoke-ai/invoke-training/issues/100 (based on the Discord discussion here: https://discord.com/channels/1020123559063990373/1130288610520875049/1227012392416841789 )

Prior to this change, invoke-training produces TI embeddings for SD1.5 in a format based on diffusers with the main key being the placeholder token:
```bash
>>> sd = load_file("bruce_the_gnome.safetensors")
>>> sd.keys()
dict_keys(['bruce_the_gnome'])
```

This format is currently failing to import into InvokeAI via the Model Manager. I suspect that this is caused by a change in behaviour during the recent MM refactor, but I haven't gone to the effort to try and confirm this.

The old diffusers format is not very popular, so instead I have switched invoke-training to use a different format, which uses `"emb_params"` as the main state_dict key.

Note that only SD1.5 is affected. The format used for SDXL TI embeddings is unchanged.