### PR TITLE
Fix checkpoint enumeration

### DIFF
--- a/src/invoke_training/_shared/stable_diffusion/validation.py
+++ b/src/invoke_training/_shared/stable_diffusion/validation.py
@@ -21,6 +21,7 @@ from invoke_training.pipelines.stable_diffusion_xl.lora.config import SdxlLoraCo
 
 
 def generate_validation_images_sd(
+    epoch: int,
     step: int,
     out_dir: str,
     accelerator: Accelerator,
@@ -31,7 +32,6 @@ def generate_validation_images_sd(
     unet: UNet2DConditionModel,
     config: SdLoraConfig,
     logger: logging.Logger,
-    prefix="epoch",
 ):
     """Generate validation images for the purpose of tracking image generation behaviour on fixed prompts throughout
     training.
@@ -88,7 +88,7 @@ def generate_validation_images_sd(
             validation_dir = os.path.join(
                 out_dir,
                 "validation",
-                f"{prefix}_{step:0>8}",
+                f"epoch_{epoch:0>8}-step_{step:0>8}",
                 f"prompt_{prompt_idx:0>4}",
             )
             os.makedirs(validation_dir)
@@ -100,7 +100,7 @@ def generate_validation_images_sd(
                 if tracker.name == "tensorboard":
                     np_images = np.stack([np.asarray(img) for img in images])
                     tracker.writer.add_images(
-                        f"validation ({prefix}) (prompt {prompt_idx})",
+                        f"validation (prompt {prompt_idx})",
                         np_images,
                         step,
                         dataformats="NHWC",
@@ -122,6 +122,7 @@ def generate_validation_images_sd(
 
 
 def generate_validation_images_sdxl(
+    epoch: int,
     step: int,
     out_dir: str,
     accelerator: Accelerator,
@@ -134,7 +135,6 @@ def generate_validation_images_sdxl(
     unet: UNet2DConditionModel,
     config: SdxlLoraConfig,
     logger: logging.Logger,
-    prefix: str = "epoch",
 ):
     """Generate validation images for the purpose of tracking image generation behaviour on fixed prompts throughout
     training.
@@ -190,7 +190,7 @@ def generate_validation_images_sdxl(
             validation_dir = os.path.join(
                 out_dir,
                 "validation",
-                f"{prefix}_{step:0>8}",
+                f"epoch_{epoch:0>8}-step_{step:0>8}",
                 f"prompt_{prompt_idx:0>4}",
             )
             os.makedirs(validation_dir)
@@ -202,7 +202,7 @@ def generate_validation_images_sdxl(
                 if tracker.name == "tensorboard":
                     np_images = np.stack([np.asarray(img) for img in images])
                     tracker.writer.add_images(
-                        f"validation ({prefix}) (prompt {prompt_idx})",
+                        f"validation (prompt {prompt_idx})",
                         np_images,
                         step,
                         dataformats="NHWC",

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -512,11 +512,12 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig):  # noqa: C901
                 accelerator.log(log, step=global_step)
                 train_loss = 0.0
 
-                if config.save_every_n_steps is not None and (global_step + 1) % config.save_every_n_steps == 0:
+                # global_step represents the *number of completed steps* at this point.
+                if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         _save_sd_lora_checkpoint(
-                            idx=global_step + 1,
+                            idx=global_step,
                             unet=accelerator.unwrap_model(unet) if training_unet else None,
                             text_encoder=accelerator.unwrap_model(text_encoder) if training_text_encoder else None,
                             logger=logger,

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -548,6 +548,7 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig):  # noqa: C901
             if accelerator.is_main_process:
                 generate_validation_images_sd(
                     epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -569,6 +569,7 @@ def train(config: SdLoraConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sd(
+                            epoch=epoch,
                             step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
@@ -579,7 +580,6 @@ def train(config: SdLoraConfig):  # noqa: C901
                             unet=unet,
                             config=config,
                             logger=logger,
-                            prefix="step",
                         )
 
             logs = {
@@ -614,7 +614,8 @@ def train(config: SdLoraConfig):  # noqa: C901
         ):
             if accelerator.is_main_process:
                 generate_validation_images_sd(
-                    step=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,
@@ -624,7 +625,6 @@ def train(config: SdLoraConfig):  # noqa: C901
                     unet=unet,
                     config=config,
                     logger=logger,
-                    prefix="epoch",
                 )
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -489,6 +489,7 @@ def train(config: SdLoraConfig):  # noqa: C901
 
     global_step = 0
     first_epoch = 0
+    completed_epochs = 0
 
     progress_bar = tqdm(
         range(global_step, num_train_steps),
@@ -531,7 +532,7 @@ def train(config: SdLoraConfig):  # noqa: C901
 
     for epoch in range(first_epoch, num_train_epochs):
         train_loss = 0.0
-        for data_batch in data_loader:
+        for data_batch_idx, data_batch in enumerate(data_loader):
             with accelerator.accumulate(unet, text_encoder):
                 loss = train_forward(
                     config=config,
@@ -563,6 +564,7 @@ def train(config: SdLoraConfig):  # noqa: C901
             if accelerator.sync_gradients:
                 progress_bar.update(1)
                 global_step += 1
+                completed_epochs = epoch if (data_batch_idx + 1) < len(data_loader) else epoch + 1
                 log = {"train_loss": train_loss}
 
                 lrs = lr_scheduler.get_last_lr()
@@ -582,14 +584,14 @@ def train(config: SdLoraConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -601,16 +603,15 @@ def train(config: SdLoraConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
-        # (epoch + 1) represents the *number of completed epochs* at this point.
-        if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+        if config.save_every_n_epochs is not None and completed_epochs % config.save_every_n_epochs == 0:
+            save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
             config.validate_every_n_epochs is not None
-            and (epoch + 1) % config.validate_every_n_epochs == 0
+            and completed_epochs % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+            validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -497,6 +497,38 @@ def train(config: SdLoraConfig):  # noqa: C901
     )
     progress_bar.set_description("Steps")
 
+    def save_checkpoint(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            _save_sd_lora_checkpoint(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                unet=accelerator.unwrap_model(unet) if config.train_unet else None,
+                text_encoder=accelerator.unwrap_model(text_encoder) if config.train_text_encoder else None,
+                logger=logger,
+                checkpoint_tracker=checkpoint_tracker,
+                lora_checkpoint_format=config.lora_checkpoint_format,
+            )
+        accelerator.wait_for_everyone()
+
+    def validate(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            generate_validation_images_sd(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                out_dir=out_dir,
+                accelerator=accelerator,
+                vae=vae,
+                text_encoder=text_encoder,
+                tokenizer=tokenizer,
+                noise_scheduler=noise_scheduler,
+                unet=unet,
+                config=config,
+                logger=logger,
+            )
+        accelerator.wait_for_everyone()
+
     for epoch in range(first_epoch, num_train_epochs):
         train_loss = 0.0
         for data_batch in data_loader:
@@ -550,37 +582,14 @@ def train(config: SdLoraConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        _save_sd_lora_checkpoint(
-                            epoch=epoch,
-                            step=global_step,
-                            unet=accelerator.unwrap_model(unet) if config.train_unet else None,
-                            text_encoder=accelerator.unwrap_model(text_encoder) if config.train_text_encoder else None,
-                            logger=logger,
-                            checkpoint_tracker=checkpoint_tracker,
-                            lora_checkpoint_format=config.lora_checkpoint_format,
-                        )
+                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
+
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        generate_validation_images_sd(
-                            epoch=epoch,
-                            step=global_step,
-                            out_dir=out_dir,
-                            accelerator=accelerator,
-                            vae=vae,
-                            text_encoder=text_encoder,
-                            tokenizer=tokenizer,
-                            noise_scheduler=noise_scheduler,
-                            unet=unet,
-                            config=config,
-                            logger=logger,
-                        )
+                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -594,17 +603,7 @@ def train(config: SdLoraConfig):  # noqa: C901
         # Save a checkpoint every n epochs.
         # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            if accelerator.is_main_process:
-                accelerator.wait_for_everyone()
-                _save_sd_lora_checkpoint(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    unet=accelerator.unwrap_model(unet) if config.train_unet else None,
-                    text_encoder=accelerator.unwrap_model(text_encoder) if config.train_text_encoder else None,
-                    logger=logger,
-                    checkpoint_tracker=checkpoint_tracker,
-                    lora_checkpoint_format=config.lora_checkpoint_format,
-                )
+            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
@@ -612,19 +611,6 @@ def train(config: SdLoraConfig):  # noqa: C901
             and (epoch + 1) % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            if accelerator.is_main_process:
-                generate_validation_images_sd(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    out_dir=out_dir,
-                    accelerator=accelerator,
-                    vae=vae,
-                    text_encoder=text_encoder,
-                    tokenizer=tokenizer,
-                    noise_scheduler=noise_scheduler,
-                    unet=unet,
-                    config=config,
-                    logger=logger,
-                )
+            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -373,6 +373,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sd(
+                            epoch=epoch,
                             step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
@@ -383,7 +384,6 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                             unet=unet,
                             config=config,
                             logger=logger,
-                            prefix="step",
                         )
 
             logs = {"step_loss": loss.detach().item(), "lr": lr_scheduler.get_last_lr()[0]}
@@ -417,7 +417,8 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
         ):
             if accelerator.is_main_process:
                 generate_validation_images_sd(
-                    step=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,
@@ -427,7 +428,6 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                     unet=unet,
                     config=config,
                     logger=logger,
-                    prefix="epoch",
                 )
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -296,6 +296,38 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
     # Keep original embeddings as reference.
     orig_embeds_params = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight.data.clone()
 
+    def save_checkpoint(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            _save_ti_embeddings(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                text_encoder=text_encoder,
+                placeholder_token_ids=placeholder_token_ids,
+                accelerator=accelerator,
+                logger=logger,
+                checkpoint_tracker=checkpoint_tracker,
+            )
+        accelerator.wait_for_everyone()
+
+    def validate(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            generate_validation_images_sd(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                out_dir=out_dir,
+                accelerator=accelerator,
+                vae=vae,
+                text_encoder=text_encoder,
+                tokenizer=tokenizer,
+                noise_scheduler=noise_scheduler,
+                unet=unet,
+                config=config,
+                logger=logger,
+            )
+        accelerator.wait_for_everyone()
+
     for epoch in range(first_epoch, num_train_epochs):
         text_encoder.train()
 
@@ -353,38 +385,14 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        _save_ti_embeddings(
-                            epoch=epoch,
-                            step=global_step,
-                            text_encoder=text_encoder,
-                            placeholder_token_ids=placeholder_token_ids,
-                            accelerator=accelerator,
-                            logger=logger,
-                            checkpoint_tracker=checkpoint_tracker,
-                        )
+                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        generate_validation_images_sd(
-                            epoch=epoch,
-                            step=global_step,
-                            out_dir=out_dir,
-                            accelerator=accelerator,
-                            vae=vae,
-                            text_encoder=text_encoder,
-                            tokenizer=tokenizer,
-                            noise_scheduler=noise_scheduler,
-                            unet=unet,
-                            config=config,
-                            logger=logger,
-                        )
+                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
 
             logs = {"step_loss": loss.detach().item(), "lr": lr_scheduler.get_last_lr()[0]}
             progress_bar.set_postfix(**logs)
@@ -395,19 +403,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
         # Save a checkpoint every n epochs.
         # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            if accelerator.is_main_process:
-                _save_ti_embeddings(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    text_encoder=text_encoder,
-                    placeholder_token_ids=placeholder_token_ids,
-                    accelerator=accelerator,
-                    logger=logger,
-                    checkpoint_tracker=checkpoint_tracker,
-                )
-                # TODO(ryand): This doesn't seem right, but it's done this way in most of the training pipelines. Should
-                # probably sync before and after saving. (Or maybe accelerate offers a context manager to handle this?)
-                accelerator.wait_for_everyone()
+            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
@@ -415,19 +411,6 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
             and (epoch + 1) % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            if accelerator.is_main_process:
-                generate_validation_images_sd(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    out_dir=out_dir,
-                    accelerator=accelerator,
-                    vae=vae,
-                    text_encoder=text_encoder,
-                    tokenizer=tokenizer,
-                    noise_scheduler=noise_scheduler,
-                    unet=unet,
-                    config=config,
-                    logger=logger,
-                )
+            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -357,11 +357,12 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                 accelerator.log(log, step=global_step)
                 train_loss = 0.0
 
-                if config.save_every_n_steps is not None and (global_step + 1) % config.save_every_n_steps == 0:
+                # global_step represents the *number of completed steps* at this point.
+                if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         _save_ti_embeddings(
-                            idx=global_step + 1,
+                            idx=global_step,
                             text_encoder=text_encoder,
                             placeholder_token_ids=placeholder_token_ids,
                             accelerator=accelerator,
@@ -371,13 +372,13 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
 
                 if (
                     config.validate_every_n_steps is not None
-                    and (global_step + 1) % config.validate_every_n_steps == 0
+                    and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sd(
-                            step=global_step + 1,
+                            step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
                             vae=vae,
@@ -397,6 +398,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
+        # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
             if accelerator.is_main_process:
                 _save_ti_embeddings(

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -285,6 +285,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
 
     global_step = 0
     first_epoch = 0
+    completed_epochs = 0
 
     progress_bar = tqdm(
         range(global_step, num_train_steps),
@@ -332,7 +333,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
         text_encoder.train()
 
         train_loss = 0.0
-        for data_batch in data_loader:
+        for data_batch_idx, data_batch in enumerate(data_loader):
             with accelerator.accumulate(text_encoder):
                 loss = train_forward(
                     config=config,
@@ -374,6 +375,7 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
             if accelerator.sync_gradients:
                 progress_bar.update(1)
                 global_step += 1
+                completed_epochs = epoch if (data_batch_idx + 1) < len(data_loader) else epoch + 1
                 log = {"train_loss": train_loss, "lr": lr_scheduler.get_last_lr()[0]}
 
                 if config.optimizer.optimizer_type == "Prodigy":
@@ -385,14 +387,14 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
             logs = {"step_loss": loss.detach().item(), "lr": lr_scheduler.get_last_lr()[0]}
             progress_bar.set_postfix(**logs)
@@ -401,16 +403,15 @@ def train(config: SdTextualInversionConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
-        # (epoch + 1) represents the *number of completed epochs* at this point.
-        if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+        if config.save_every_n_epochs is not None and completed_epochs % config.save_every_n_epochs == 0:
+            save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
             config.validate_every_n_epochs is not None
-            and (epoch + 1) % config.validate_every_n_epochs == 0
+            and completed_epochs % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+            validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -666,6 +666,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sdxl(
+                            epoch=epoch,
                             step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
@@ -678,7 +679,6 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                             unet=unet,
                             config=config,
                             logger=logger,
-                            prefix="step",
                         )
 
             logs = {
@@ -714,7 +714,8 @@ def train(config: SdxlLoraConfig):  # noqa: C901
         ):
             if accelerator.is_main_process:
                 generate_validation_images_sdxl(
-                    step=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,
@@ -726,7 +727,6 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                     unet=unet,
                     config=config,
                     logger=logger,
-                    prefix="epoch",
                 )
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -25,12 +25,8 @@ from invoke_training._shared.accelerator.accelerator_utils import (
     initialize_logging,
 )
 from invoke_training._shared.checkpoints.checkpoint_tracker import CheckpointTracker
-from invoke_training._shared.data.data_loaders.dreambooth_sd_dataloader import (
-    build_dreambooth_sd_dataloader,
-)
-from invoke_training._shared.data.data_loaders.image_caption_sd_dataloader import (
-    build_image_caption_sd_dataloader,
-)
+from invoke_training._shared.data.data_loaders.dreambooth_sd_dataloader import build_dreambooth_sd_dataloader
+from invoke_training._shared.data.data_loaders.image_caption_sd_dataloader import build_image_caption_sd_dataloader
 from invoke_training._shared.data.samplers.aspect_ratio_bucket_batch_sampler import log_aspect_ratio_buckets
 from invoke_training._shared.data.transforms.tensor_disk_cache import TensorDiskCache
 from invoke_training._shared.data.utils.resolution import Resolution
@@ -42,15 +38,10 @@ from invoke_training._shared.stable_diffusion.lora_checkpoint_utils import (
     save_sdxl_peft_checkpoint,
 )
 from invoke_training._shared.stable_diffusion.min_snr_weighting import compute_snr
-from invoke_training._shared.stable_diffusion.model_loading_utils import (
-    load_models_sdxl,
-)
+from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
-from invoke_training.config.data.data_loader_config import (
-    DreamboothSDDataLoaderConfig,
-    ImageCaptionSDDataLoaderConfig,
-)
+from invoke_training.config.data.data_loader_config import DreamboothSDDataLoaderConfig, ImageCaptionSDDataLoaderConfig
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_vae_outputs
 from invoke_training.pipelines.stable_diffusion_xl.lora.config import SdxlLoraConfig
 
@@ -658,11 +649,12 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                 accelerator.log(log, step=global_step)
                 train_loss = 0.0
 
-                if config.save_every_n_steps is not None and (global_step + 1) % config.save_every_n_steps == 0:
+                # global_step represents the *number of completed steps* at this point.
+                if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         _save_sdxl_lora_checkpoint(
-                            idx=global_step + 1,
+                            idx=global_step,
                             unet=unet if config.train_unet else None,
                             text_encoder_1=text_encoder_1 if config.train_text_encoder else None,
                             text_encoder_2=text_encoder_2 if config.train_text_encoder else None,
@@ -673,13 +665,13 @@ def train(config: SdxlLoraConfig):  # noqa: C901
 
                 if (
                     config.validate_every_n_steps is not None
-                    and (global_step + 1) % config.validate_every_n_steps == 0
+                    and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sdxl(
-                            step=global_step + 1,
+                            step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
                             vae=vae,
@@ -704,6 +696,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
+        # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
             if accelerator.is_main_process:
                 _save_sdxl_lora_checkpoint(

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -580,6 +580,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
 
     global_step = 0
     first_epoch = 0
+    completed_epochs = 0
 
     progress_bar = tqdm(
         range(global_step, num_train_steps),
@@ -625,7 +626,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
 
     for epoch in range(first_epoch, num_train_epochs):
         train_loss = 0.0
-        for data_batch in data_loader:
+        for data_batch_idx, data_batch in enumerate(data_loader):
             with accelerator.accumulate(unet, text_encoder_1, text_encoder_2):
                 loss = train_forward(
                     accelerator=accelerator,
@@ -661,6 +662,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
             if accelerator.sync_gradients:
                 progress_bar.update(1)
                 global_step += 1
+                completed_epochs = epoch if (data_batch_idx + 1) < len(data_loader) else epoch + 1
                 log = {"train_loss": train_loss}
 
                 lrs = lr_scheduler.get_last_lr()
@@ -680,14 +682,14 @@ def train(config: SdxlLoraConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -699,16 +701,15 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
-        # (epoch + 1) represents the *number of completed epochs* at this point.
-        if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+        if config.save_every_n_epochs is not None and completed_epochs % config.save_every_n_epochs == 0:
+            save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
             config.validate_every_n_epochs is not None
-            and (epoch + 1) % config.validate_every_n_epochs == 0
+            and completed_epochs % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+            validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -347,6 +347,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
 
     global_step = 0
     first_epoch = 0
+    completed_epochs = first_epoch
 
     progress_bar = tqdm(
         range(global_step, num_train_steps),
@@ -410,7 +411,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
         text_encoder_2.train()
 
         train_loss = 0.0
-        for data_batch in data_loader:
+        for data_batch_idx, data_batch in enumerate(data_loader):
             if global_step == ti_train_steps and config.train_ti:
                 logger.info("Reached TI training pivot point. Setting TI learning rate to 0.0.")
                 # TODO(ryand): The TI embeddings continue to be updated slightly by the normalization step in
@@ -474,6 +475,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
             if accelerator.sync_gradients:
                 progress_bar.update(1)
                 global_step += 1
+                completed_epochs = epoch if (data_batch_idx + 1) < len(data_loader) else epoch + 1
                 log = {"train_loss": train_loss}
 
                 lrs = lr_scheduler.get_last_lr()
@@ -502,14 +504,14 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
+                    validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -521,16 +523,15 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                 break
 
         # Save a checkpoint every n epochs.
-        # (epoch + 1) represents the *number of completed epochs* at this point.
-        if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+        if config.save_every_n_epochs is not None and completed_epochs % config.save_every_n_epochs == 0:
+            save_checkpoint(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
             config.validate_every_n_epochs is not None
-            and (epoch + 1) % config.validate_every_n_epochs == 0
+            and completed_epochs % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
+            validate(num_completed_epochs=completed_epochs, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -488,6 +488,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sdxl(
+                            epoch=epoch,
                             step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
@@ -500,7 +501,6 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                             unet=unet,
                             config=config,
                             logger=logger,
-                            prefix="step",
                         )
             logs = {
                 "step_loss": loss.detach().item(),
@@ -539,7 +539,8 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
         ):
             if accelerator.is_main_process:
                 generate_validation_images_sdxl(
-                    step=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,
@@ -551,7 +552,6 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                     unet=unet,
                     config=config,
                     logger=logger,
-                    prefix="epoch",
                 )
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -365,6 +365,45 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
         orig_embeds_params_1 = accelerator.unwrap_model(text_encoder_1).get_input_embeddings().weight.data.clone()
         orig_embeds_params_2 = accelerator.unwrap_model(text_encoder_2).get_input_embeddings().weight.data.clone()
 
+    def save_checkpoint(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            _save_sdxl_lora_and_ti_checkpoint(
+                config=config,
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                unet=unet,
+                text_encoder_1=text_encoder_1,
+                text_encoder_2=text_encoder_2,
+                placeholder_token_ids_1=placeholder_token_ids_1,
+                placeholder_token_ids_2=placeholder_token_ids_2,
+                accelerator=accelerator,
+                logger=logger,
+                checkpoint_tracker=checkpoint_tracker,
+                lora_checkpoint_format=config.lora_checkpoint_format,
+            )
+        accelerator.wait_for_everyone()
+
+    def validate(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            generate_validation_images_sdxl(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                out_dir=out_dir,
+                accelerator=accelerator,
+                vae=vae,
+                text_encoder_1=text_encoder_1,
+                text_encoder_2=text_encoder_2,
+                tokenizer_1=tokenizer_1,
+                tokenizer_2=tokenizer_2,
+                noise_scheduler=noise_scheduler,
+                unet=unet,
+                config=config,
+                logger=logger,
+            )
+        accelerator.wait_for_everyone()
+
     for epoch in range(first_epoch, num_train_epochs):
         # TODO(ryand): Is this necessary?
         text_encoder_1.train()
@@ -463,45 +502,15 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        _save_sdxl_lora_and_ti_checkpoint(
-                            config=config,
-                            epoch=epoch,
-                            step=global_step,
-                            unet=unet,
-                            text_encoder_1=text_encoder_1,
-                            text_encoder_2=text_encoder_2,
-                            placeholder_token_ids_1=placeholder_token_ids_1,
-                            placeholder_token_ids_2=placeholder_token_ids_2,
-                            accelerator=accelerator,
-                            logger=logger,
-                            checkpoint_tracker=checkpoint_tracker,
-                            lora_checkpoint_format=config.lora_checkpoint_format,
-                        )
+                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        generate_validation_images_sdxl(
-                            epoch=epoch,
-                            step=global_step,
-                            out_dir=out_dir,
-                            accelerator=accelerator,
-                            vae=vae,
-                            text_encoder_1=text_encoder_1,
-                            text_encoder_2=text_encoder_2,
-                            tokenizer_1=tokenizer_1,
-                            tokenizer_2=tokenizer_2,
-                            noise_scheduler=noise_scheduler,
-                            unet=unet,
-                            config=config,
-                            logger=logger,
-                        )
+                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
+
             logs = {
                 "step_loss": loss.detach().item(),
                 "lr": lr_scheduler.get_last_lr()[0],
@@ -514,22 +523,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
         # Save a checkpoint every n epochs.
         # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            if accelerator.is_main_process:
-                _save_sdxl_lora_and_ti_checkpoint(
-                    config=config,
-                    epoch=epoch + 1,
-                    step=global_step,
-                    unet=unet,
-                    text_encoder_1=text_encoder_1,
-                    text_encoder_2=text_encoder_2,
-                    placeholder_token_ids_1=placeholder_token_ids_1,
-                    placeholder_token_ids_2=placeholder_token_ids_2,
-                    accelerator=accelerator,
-                    logger=logger,
-                    checkpoint_tracker=checkpoint_tracker,
-                    lora_checkpoint_format=config.lora_checkpoint_format,
-                )
-                accelerator.wait_for_everyone()
+            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
@@ -537,21 +531,6 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
             and (epoch + 1) % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            if accelerator.is_main_process:
-                generate_validation_images_sdxl(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    out_dir=out_dir,
-                    accelerator=accelerator,
-                    vae=vae,
-                    text_encoder_1=text_encoder_1,
-                    text_encoder_2=text_encoder_2,
-                    tokenizer_1=tokenizer_1,
-                    tokenizer_2=tokenizer_2,
-                    noise_scheduler=noise_scheduler,
-                    unet=unet,
-                    config=config,
-                    logger=logger,
-                )
+            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -40,7 +40,8 @@ from invoke_training.pipelines.stable_diffusion_xl.textual_inversion.config impo
 
 
 def _save_ti_embeddings(
-    idx: int,
+    epoch: int,
+    step: int,
     text_encoder_1: CLIPTextModel,
     text_encoder_2: CLIPTextModel,
     placeholder_token_ids_1: list[int],
@@ -56,7 +57,7 @@ def _save_ti_embeddings(
     num_pruned = checkpoint_tracker.prune(1)
     if num_pruned > 0:
         logger.info(f"Pruned {num_pruned} checkpoint(s).")
-    save_path = checkpoint_tracker.get_path(idx)
+    save_path = checkpoint_tracker.get_path(epoch=epoch, step=step)
 
     learned_embeds_1 = (
         accelerator.unwrap_model(text_encoder_1)
@@ -298,16 +299,9 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
         # Tensorboard uses markdown formatting, so we wrap the config json in a code block.
         accelerator.log({"configuration": f"```json\n{json.dumps(config.dict(), indent=2, default=str)}\n```\n"})
 
-    epoch_checkpoint_tracker = CheckpointTracker(
+    checkpoint_tracker = CheckpointTracker(
         base_dir=ckpt_dir,
-        prefix="checkpoint_epoch",
-        extension=".safetensors",
-        max_checkpoints=config.max_checkpoints,
-    )
-
-    step_checkpoint_tracker = CheckpointTracker(
-        base_dir=ckpt_dir,
-        prefix="checkpoint_step",
+        prefix="checkpoint",
         extension=".safetensors",
         max_checkpoints=config.max_checkpoints,
     )
@@ -411,14 +405,15 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         _save_ti_embeddings(
-                            idx=global_step,
+                            epoch=epoch,
+                            step=global_step,
                             text_encoder_1=text_encoder_1,
                             text_encoder_2=text_encoder_2,
                             placeholder_token_ids_1=placeholder_token_ids_1,
                             placeholder_token_ids_2=placeholder_token_ids_2,
                             accelerator=accelerator,
                             logger=logger,
-                            checkpoint_tracker=step_checkpoint_tracker,
+                            checkpoint_tracker=checkpoint_tracker,
                         )
 
                 if (
@@ -458,14 +453,15 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
             if accelerator.is_main_process:
                 _save_ti_embeddings(
-                    idx=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     text_encoder_1=text_encoder_1,
                     text_encoder_2=text_encoder_2,
                     placeholder_token_ids_1=placeholder_token_ids_1,
                     placeholder_token_ids_2=placeholder_token_ids_2,
                     accelerator=accelerator,
                     logger=logger,
-                    checkpoint_tracker=epoch_checkpoint_tracker,
+                    checkpoint_tracker=checkpoint_tracker,
                 )
                 # TODO(ryand): This doesn't seem right, but it's done this way in most of the training pipelines. Should
                 # probably sync before and after saving. (Or maybe accelerate offers a context manager to handle this?)

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -424,6 +424,7 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         generate_validation_images_sdxl(
+                            epoch=epoch,
                             step=global_step,
                             out_dir=out_dir,
                             accelerator=accelerator,
@@ -436,7 +437,6 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                             unet=unet,
                             config=config,
                             logger=logger,
-                            prefix="step",
                         )
 
             logs = {
@@ -475,7 +475,8 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
         ):
             if accelerator.is_main_process:
                 generate_validation_images_sdxl(
-                    step=epoch + 1,
+                    epoch=epoch + 1,
+                    step=global_step,
                     out_dir=out_dir,
                     accelerator=accelerator,
                     vae=vae,
@@ -487,7 +488,6 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                     unet=unet,
                     config=config,
                     logger=logger,
-                    prefix="epoch",
                 )
 
     accelerator.end_training()

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -332,6 +332,42 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
         orig_embeds_params_1 = accelerator.unwrap_model(text_encoder_1).get_input_embeddings().weight.data.clone()
         orig_embeds_params_2 = accelerator.unwrap_model(text_encoder_2).get_input_embeddings().weight.data.clone()
 
+    def save_checkpoint(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            _save_ti_embeddings(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                text_encoder_1=text_encoder_1,
+                text_encoder_2=text_encoder_2,
+                placeholder_token_ids_1=placeholder_token_ids_1,
+                placeholder_token_ids_2=placeholder_token_ids_2,
+                accelerator=accelerator,
+                logger=logger,
+                checkpoint_tracker=checkpoint_tracker,
+            )
+        accelerator.wait_for_everyone()
+
+    def validate(num_completed_epochs: int, num_completed_steps: int):
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            generate_validation_images_sdxl(
+                epoch=num_completed_epochs,
+                step=num_completed_steps,
+                out_dir=out_dir,
+                accelerator=accelerator,
+                vae=vae,
+                text_encoder_1=text_encoder_1,
+                text_encoder_2=text_encoder_2,
+                tokenizer_1=tokenizer_1,
+                tokenizer_2=tokenizer_2,
+                noise_scheduler=noise_scheduler,
+                unet=unet,
+                config=config,
+                logger=logger,
+            )
+        accelerator.wait_for_everyone()
+
     for epoch in range(first_epoch, num_train_epochs):
         text_encoder_1.train()
         text_encoder_2.train()
@@ -402,42 +438,14 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
 
                 # global_step represents the *number of completed steps* at this point.
                 if config.save_every_n_steps is not None and global_step % config.save_every_n_steps == 0:
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        _save_ti_embeddings(
-                            epoch=epoch,
-                            step=global_step,
-                            text_encoder_1=text_encoder_1,
-                            text_encoder_2=text_encoder_2,
-                            placeholder_token_ids_1=placeholder_token_ids_1,
-                            placeholder_token_ids_2=placeholder_token_ids_2,
-                            accelerator=accelerator,
-                            logger=logger,
-                            checkpoint_tracker=checkpoint_tracker,
-                        )
+                    save_checkpoint(num_completed_epochs=epoch, num_completed_steps=global_step)
 
                 if (
                     config.validate_every_n_steps is not None
                     and global_step % config.validate_every_n_steps == 0
                     and len(config.validation_prompts) > 0
                 ):
-                    accelerator.wait_for_everyone()
-                    if accelerator.is_main_process:
-                        generate_validation_images_sdxl(
-                            epoch=epoch,
-                            step=global_step,
-                            out_dir=out_dir,
-                            accelerator=accelerator,
-                            vae=vae,
-                            text_encoder_1=text_encoder_1,
-                            text_encoder_2=text_encoder_2,
-                            tokenizer_1=tokenizer_1,
-                            tokenizer_2=tokenizer_2,
-                            noise_scheduler=noise_scheduler,
-                            unet=unet,
-                            config=config,
-                            logger=logger,
-                        )
+                    validate(num_completed_epochs=epoch, num_completed_steps=global_step)
 
             logs = {
                 "step_loss": loss.detach().item(),
@@ -451,21 +459,7 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
         # Save a checkpoint every n epochs.
         # (epoch + 1) represents the *number of completed epochs* at this point.
         if config.save_every_n_epochs is not None and (epoch + 1) % config.save_every_n_epochs == 0:
-            if accelerator.is_main_process:
-                _save_ti_embeddings(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    text_encoder_1=text_encoder_1,
-                    text_encoder_2=text_encoder_2,
-                    placeholder_token_ids_1=placeholder_token_ids_1,
-                    placeholder_token_ids_2=placeholder_token_ids_2,
-                    accelerator=accelerator,
-                    logger=logger,
-                    checkpoint_tracker=checkpoint_tracker,
-                )
-                # TODO(ryand): This doesn't seem right, but it's done this way in most of the training pipelines. Should
-                # probably sync before and after saving. (Or maybe accelerate offers a context manager to handle this?)
-                accelerator.wait_for_everyone()
+            save_checkpoint(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
         # Generate validation images every n epochs.
         if (
@@ -473,21 +467,6 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
             and (epoch + 1) % config.validate_every_n_epochs == 0
             and len(config.validation_prompts) > 0
         ):
-            if accelerator.is_main_process:
-                generate_validation_images_sdxl(
-                    epoch=epoch + 1,
-                    step=global_step,
-                    out_dir=out_dir,
-                    accelerator=accelerator,
-                    vae=vae,
-                    text_encoder_1=text_encoder_1,
-                    text_encoder_2=text_encoder_2,
-                    tokenizer_1=tokenizer_1,
-                    tokenizer_2=tokenizer_2,
-                    noise_scheduler=noise_scheduler,
-                    unet=unet,
-                    config=config,
-                    logger=logger,
-                )
+            validate(num_completed_epochs=epoch + 1, num_completed_steps=global_step)
 
     accelerator.end_training()

--- a/tests/invoke_training/_shared/checkpoints/test_checkpoint_tracker.py
+++ b/tests/invoke_training/_shared/checkpoints/test_checkpoint_tracker.py
@@ -16,9 +16,9 @@ def test_checkpoint_tracker_get_path_file():
         index_padding=8,
     )
 
-    path = checkpoint_tracker.get_path(55)
+    path = checkpoint_tracker.get_path(epoch=1, step=55)
 
-    assert Path(path) == Path("base_dir/prefix-00000055.ckpt")
+    assert Path(path) == Path("base_dir/prefix-epoch_00000001-step_00000055.ckpt")
 
 
 def test_checkpoint_tracker_get_path_directory():
@@ -30,9 +30,9 @@ def test_checkpoint_tracker_get_path_directory():
         index_padding=8,
     )
 
-    path = checkpoint_tracker.get_path(55)
+    path = checkpoint_tracker.get_path(epoch=1, step=55)
 
-    assert Path(path) == Path("base_dir/prefix-00000055")
+    assert Path(path) == Path("base_dir/prefix-epoch_00000001-step_00000055")
 
 
 def test_checkpoint_tracker_bad_extension():
@@ -49,17 +49,17 @@ def test_checkpoint_tracker_prune_files():
         checkpoint_tracker = CheckpointTracker(base_dir=dir_name, prefix="prefix", extension=".ckpt", max_checkpoints=5)
         # Create 6 checkpoints.
         for i in range(6):
-            path = checkpoint_tracker.get_path(i)
+            path = checkpoint_tracker.get_path(epoch=0, step=i)
             with open(path, "w") as f:
                 f.write("hi")
 
-        # Prune the 3 checkpoints with the lowest indices.
+        # Prune the 3 checkpoints with the lowest step counts.
         num_pruned = checkpoint_tracker.prune(2)
         assert num_pruned == 3
 
         # Verify that the correct checkpoints were pruned.
-        assert all([not os.path.exists(checkpoint_tracker.get_path(i)) for i in range(3)])
-        assert all([os.path.exists(checkpoint_tracker.get_path(i)) for i in range(3, 6)])
+        assert all([not os.path.exists(checkpoint_tracker.get_path(epoch=0, step=i)) for i in range(3)])
+        assert all([os.path.exists(checkpoint_tracker.get_path(epoch=0, step=i)) for i in range(3, 6)])
 
 
 def test_checkpoint_tracker_prune_directories():
@@ -68,7 +68,7 @@ def test_checkpoint_tracker_prune_directories():
         checkpoint_tracker = CheckpointTracker(base_dir=dir_name, prefix="prefix", extension=None, max_checkpoints=5)
         # Create 6 checkpoints.
         for i in range(6):
-            path = checkpoint_tracker.get_path(i)
+            path = checkpoint_tracker.get_path(epoch=0, step=i)
             # Create checkpoint directory and add file to it.
             os.makedirs(path)
             with open(os.path.join(path, "tmp.txt"), "w") as f:
@@ -79,8 +79,8 @@ def test_checkpoint_tracker_prune_directories():
         assert num_pruned == 3
 
         # Verify that the correct checkpoints were pruned.
-        assert all([not os.path.exists(checkpoint_tracker.get_path(i)) for i in range(3)])
-        assert all([os.path.exists(checkpoint_tracker.get_path(i)) for i in range(3, 6)])
+        assert all([not os.path.exists(checkpoint_tracker.get_path(epoch=0, step=i)) for i in range(3)])
+        assert all([os.path.exists(checkpoint_tracker.get_path(epoch=0, step=i)) for i in range(3, 6)])
 
 
 def test_checkpoint_tracker_prune_no_max():
@@ -91,7 +91,7 @@ def test_checkpoint_tracker_prune_no_max():
         )
         # Create 6 checkpoints.
         for i in range(6):
-            path = checkpoint_tracker.get_path(i)
+            path = checkpoint_tracker.get_path(epoch=0, step=i)
             with open(path, "w") as f:
                 f.write("hi")
 
@@ -100,4 +100,4 @@ def test_checkpoint_tracker_prune_no_max():
         assert num_pruned == 0
 
         # Verify that no checkpoints were deleted.
-        assert all([os.path.exists(checkpoint_tracker.get_path(i)) for i in range(6)])
+        assert all([os.path.exists(checkpoint_tracker.get_path(epoch=0, step=i)) for i in range(6)])


### PR DESCRIPTION
This PR makes the following changes to how checkpoints and validation directories are stored:
- Paths now contains both the epoch and step count.
- Fixed an existing off-by-one error in the reported step counts.
- Minor refactoring to reduce code duplication.

Sample output structure:
```bash
output/sdxl_lora_and_ti_bruce_the_gnome/1713403755.9702194/
├── checkpoints
│   └── checkpoint-epoch_00000050-step_00000200
│       ├── embeddings.safetensors
│       └── lora.safetensors
├── config.json
├── logs
│   └── lora_and_ti_training
│       └── events.out.tfevents.1713403764.ryan-desktop.779613.0
└── validation
    └── epoch_00000050-step_00000200
        ├── prompt_0000
        │   ├── 0000.jpg
        │   ├── 0001.jpg
        │   └── 0002.jpg
        └── prompt_0001
            ├── 0000.jpg
            ├── 0001.jpg
            └── 0002.jpg
```