### PR TITLE
Add on_save_checkpoint() and on_save_validation_images() callbacks

### DIFF
--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -39,6 +39,7 @@ from invoke_training._shared.stable_diffusion.model_loading_utils import load_mo
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sd
 from invoke_training.pipelines._experimental.sd_dpo_lora.config import SdDirectPreferenceOptimizationLoraConfig
+from invoke_training.pipelines.callbacks import PipelineCallbacks
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_text_encoder_outputs
 
 
@@ -186,7 +187,10 @@ def train_forward_dpo(  # noqa: C901
     return loss
 
 
-def train(config: SdDirectPreferenceOptimizationLoraConfig):  # noqa: C901
+def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[PipelineCallbacks] | None = None):  # noqa: C901
+    if callbacks:
+        raise ValueError(f"This pipeline does not support callbacks, but {len(callbacks)} were provided.")
+
     # Give a clear error message if an unsupported base model was chosen.
     # TODO(ryan): Update this check to work with single-file SD checkpoints.
     # check_base_model_version(

--- a/src/invoke_training/pipelines/callbacks.py
+++ b/src/invoke_training/pipelines/callbacks.py
@@ -1,0 +1,68 @@
+from abc import ABC
+from enum import Enum
+
+
+class ModelType(Enum):
+    # At first glance, it feels like these model types should be further broken down into separate enums (e.g.
+    # base_model, model_type, checkpoint_format). But, I haven't yet come up with a taxonomy that feels sufficiently
+    # future-proof. So, for now, there is one enum for each file type that invoke-training can produce.
+
+    # A Stable Diffusion 1.x LoRA model in Kohya format.
+    SD1_LORA_KOHYA = "SD1_LORA_KOHYA"
+    # A Stable Diffusion 1.x LoRA model in PEFT format.
+    SD1_LORA_PEFT = "SD1_LORA_PEFT"
+    # A Stable Diffusion XL LoRA model in Kohya format.
+    SDXL_LORA_KOHYA = "SDXL_LORA_KOHYA"
+    # A Stable Diffusion XL LoRA model in PEFT format.
+    SDXL_LORA_PEFT = "SDXL_LORA_PEFT"
+
+    # A Stable Diffusion 1.x Textual Inversion model.
+    SD1_TEXTUAL_INVERSION = "SD1_TEXTUAL_INVERSION"
+    # A Stable Diffusion XL Textual Inversion model.
+    SDXL_TEXTUAL_INVERSION = "SDXL_TEXTUAL_INVERSION"
+
+
+class ModelCheckpoint:
+    """A single model checkpoint."""
+
+    def __init__(self, file_path: str, model_type: ModelType):
+        self.file_path = file_path
+        self.model_type = model_type
+
+
+class TrainingCheckpoint:
+    """A training checkpoint. May contain multiple model checkpoints if multiple models are being trained
+    simultaneously.
+    """
+
+    def __init__(self, models: list[ModelCheckpoint], epoch: int, step: int):
+        self.models = models
+        self.epoch = epoch
+        self.step = step
+
+
+class ValidationImage:
+    def __init__(self, file_path: str, prompt: str, image_idx: int, epoch: int, step: int):
+        """A single validation image.
+
+        Args:
+            file_path (str): Path to the image file.
+            prompt (str): The prompt used to generate the image.
+            image_idx (int): The index of this image in the current validation set (i.e. in the set of images generated
+                with the same prompt at the same validation point).
+            epoch (int): The last completed epoch at the time that this image was generated.
+            step (int): The last completed training step at the time that this image was generated.
+        """
+        self.file_path = file_path
+        self.prompt = prompt
+        self.image_idx = image_idx
+        self.epoch = epoch
+        self.step = step
+
+
+class PipelineCallbacks(ABC):
+    def on_save_checkpoint(self, checkpoint: TrainingCheckpoint):
+        pass
+
+    def on_save_validation_images(self, checkpoint: TrainingCheckpoint):
+        pass

--- a/src/invoke_training/pipelines/callbacks.py
+++ b/src/invoke_training/pipelines/callbacks.py
@@ -42,7 +42,7 @@ class TrainingCheckpoint:
 
 
 class ValidationImage:
-    def __init__(self, file_path: str, prompt: str, image_idx: int, epoch: int, step: int):
+    def __init__(self, file_path: str, prompt: str, image_idx: int):
         """A single validation image.
 
         Args:
@@ -50,12 +50,22 @@ class ValidationImage:
             prompt (str): The prompt used to generate the image.
             image_idx (int): The index of this image in the current validation set (i.e. in the set of images generated
                 with the same prompt at the same validation point).
-            epoch (int): The last completed epoch at the time that this image was generated.
-            step (int): The last completed training step at the time that this image was generated.
         """
         self.file_path = file_path
         self.prompt = prompt
         self.image_idx = image_idx
+
+
+class ValidationImages:
+    def __init__(self, images: list[ValidationImage], epoch: int, step: int):
+        """A collection of validation images.
+
+        Args:
+            images (list[ValidationImage]): The validation images.
+            epoch (int): The last completed epoch at the time that these images were generated.
+            step (int): The last completed training step at the time that these images were generated.
+        """
+        self.images = images
         self.epoch = epoch
         self.step = step
 
@@ -64,5 +74,5 @@ class PipelineCallbacks(ABC):
     def on_save_checkpoint(self, checkpoint: TrainingCheckpoint):
         pass
 
-    def on_save_validation_images(self, checkpoint: TrainingCheckpoint):
+    def on_save_validation_images(self, images: ValidationImages):
         pass

--- a/src/invoke_training/pipelines/invoke_train.py
+++ b/src/invoke_training/pipelines/invoke_train.py
@@ -20,15 +20,15 @@ def train(config: PipelineConfig, callbacks: list[PipelineCallbacks] | None = No
     if config.type == "SD_LORA":
         train_sd_lora(config, callbacks)
     elif config.type == "SDXL_LORA":
-        train_sdxl_lora(config)
+        train_sdxl_lora(config, callbacks)
     elif config.type == "SD_TEXTUAL_INVERSION":
-        train_sd_ti(config)
+        train_sd_ti(config, callbacks)
     elif config.type == "SDXL_TEXTUAL_INVERSION":
-        train_sdxl_ti(config)
+        train_sdxl_ti(config, callbacks)
     elif config.type == "SDXL_LORA_AND_TEXTUAL_INVERSION":
-        train_sdxl_lora_and_ti(config)
+        train_sdxl_lora_and_ti(config, callbacks)
     elif config.type == "SD_DIRECT_PREFERENCE_OPTIMIZATION_LORA":
         print(f"Running EXPERIMENTAL pipeline: '{config.type}'.")
-        train_sd_ddpo_lora(config)
+        train_sd_ddpo_lora(config, callbacks)
     else:
         raise ValueError(f"Unexpected pipeline type: '{config.type}'.")

--- a/src/invoke_training/pipelines/invoke_train.py
+++ b/src/invoke_training/pipelines/invoke_train.py
@@ -1,5 +1,6 @@
 from invoke_training.config.pipeline_config import PipelineConfig
 from invoke_training.pipelines._experimental.sd_dpo_lora.train import train as train_sd_ddpo_lora
+from invoke_training.pipelines.callbacks import PipelineCallbacks
 from invoke_training.pipelines.stable_diffusion.lora.train import train as train_sd_lora
 from invoke_training.pipelines.stable_diffusion.textual_inversion.train import train as train_sd_ti
 from invoke_training.pipelines.stable_diffusion_xl.lora.train import train as train_sdxl_lora
@@ -9,9 +10,15 @@ from invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.tr
 from invoke_training.pipelines.stable_diffusion_xl.textual_inversion.train import train as train_sdxl_ti
 
 
-def train(config: PipelineConfig):
+def train(config: PipelineConfig, callbacks: list[PipelineCallbacks] | None = None):
+    """This is the main entry point for all training pipelines."""
+
+    # Fail early if invalid callback types are provided, rather than failing later when the callbacks are used.
+    for cb in callbacks or []:
+        assert isinstance(cb, PipelineCallbacks)
+
     if config.type == "SD_LORA":
-        train_sd_lora(config)
+        train_sd_lora(config, callbacks)
     elif config.type == "SDXL_LORA":
         train_sdxl_lora(config)
     elif config.type == "SD_TEXTUAL_INVERSION":

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -73,7 +73,7 @@ def _save_sd_lora_checkpoint(
         for cb in callbacks:
             cb.on_save_checkpoint(
                 TrainingCheckpoint(
-                    models=[ModelCheckpoint(path=save_path, model_type=model_type)], epoch=epoch, step=step
+                    models=[ModelCheckpoint(file_path=save_path, model_type=model_type)], epoch=epoch, step=step
                 )
             )
 

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -40,6 +40,7 @@ from invoke_training._shared.stable_diffusion.model_loading_utils import load_mo
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sd
 from invoke_training.config.data.data_loader_config import DreamboothSDDataLoaderConfig, ImageCaptionSDDataLoaderConfig
+from invoke_training.pipelines.callbacks import PipelineCallbacks
 from invoke_training.pipelines.stable_diffusion.lora.config import SdLoraConfig
 
 
@@ -241,7 +242,7 @@ def train_forward(  # noqa: C901
     return loss.mean()
 
 
-def train(config: SdLoraConfig):  # noqa: C901
+def train(config: SdLoraConfig, callbacks: list[PipelineCallbacks] | None = None):  # noqa: C901
     # Give a clear error message if an unsupported base model was chosen.
     # TODO(ryan): Update this check to work with single-file SD checkpoints.
     # check_base_model_version(

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -69,7 +69,7 @@ def _save_ti_embeddings(
         for cb in callbacks:
             cb.on_save_checkpoint(
                 TrainingCheckpoint(
-                    models=[ModelCheckpoint(path=save_path, model_type=ModelType.SD1_TEXTUAL_INVERSION)],
+                    models=[ModelCheckpoint(file_path=save_path, model_type=ModelType.SD1_TEXTUAL_INVERSION)],
                     epoch=epoch,
                     step=step,
                 )

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -81,7 +81,7 @@ def _save_sdxl_lora_checkpoint(
         for cb in callbacks:
             cb.on_save_checkpoint(
                 TrainingCheckpoint(
-                    models=[ModelCheckpoint(path=save_path, model_type=model_type)], epoch=epoch, step=step
+                    models=[ModelCheckpoint(file_path=save_path, model_type=model_type)], epoch=epoch, step=step
                 )
             )
 

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -42,6 +42,7 @@ from invoke_training._shared.stable_diffusion.model_loading_utils import load_mo
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
 from invoke_training.config.data.data_loader_config import DreamboothSDDataLoaderConfig, ImageCaptionSDDataLoaderConfig
+from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_vae_outputs
 from invoke_training.pipelines.stable_diffusion_xl.lora.config import SdxlLoraConfig
 
@@ -55,6 +56,7 @@ def _save_sdxl_lora_checkpoint(
     logger: logging.Logger,
     checkpoint_tracker: CheckpointTracker,
     lora_checkpoint_format: Literal["invoke_peft", "kohya"],
+    callbacks: list[PipelineCallbacks] | None,
 ):
     # Prune checkpoints and get new checkpoint path.
     num_pruned = checkpoint_tracker.prune(1)
@@ -63,15 +65,25 @@ def _save_sdxl_lora_checkpoint(
     save_path = checkpoint_tracker.get_path(epoch=epoch, step=step)
 
     if lora_checkpoint_format == "invoke_peft":
+        model_type = ModelType.SD1_LORA_PEFT
         save_sdxl_peft_checkpoint(
             Path(save_path), unet=unet, text_encoder_1=text_encoder_1, text_encoder_2=text_encoder_2
         )
     elif lora_checkpoint_format == "kohya":
+        model_type = ModelType.SD1_LORA_KOHYA
         save_sdxl_kohya_checkpoint(
             Path(save_path), unet=unet, text_encoder_1=text_encoder_1, text_encoder_2=text_encoder_2
         )
     else:
         raise ValueError(f"Unsupported lora_checkpoint_format: '{lora_checkpoint_format}'.")
+
+    if callbacks is not None:
+        for cb in callbacks:
+            cb.on_save_checkpoint(
+                TrainingCheckpoint(
+                    models=[ModelCheckpoint(path=save_path, model_type=model_type)], epoch=epoch, step=step
+                )
+            )
 
 
 def _build_data_loader(
@@ -309,7 +321,7 @@ def train_forward(  # noqa: C901
     return loss.mean()
 
 
-def train(config: SdxlLoraConfig):  # noqa: C901
+def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = None):  # noqa: C901
     # Give a clear error message if an unsupported base model was chosen.
     # TODO(ryan): Update this check to work with single-file SD checkpoints.
     # check_base_model_version(
@@ -601,6 +613,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                 logger=logger,
                 checkpoint_tracker=checkpoint_tracker,
                 lora_checkpoint_format=config.lora_checkpoint_format,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 
@@ -621,6 +634,7 @@ def train(config: SdxlLoraConfig):  # noqa: C901
                 unet=unet,
                 config=config,
                 logger=logger,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -38,6 +38,7 @@ from invoke_training._shared.stable_diffusion.lora_checkpoint_utils import (
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training._shared.stable_diffusion.textual_inversion import restore_original_embeddings
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
+from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion_xl.lora.train import train_forward
 from invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.config import (
     SdxlLoraAndTextualInversionConfig,
@@ -58,12 +59,15 @@ def _save_sdxl_lora_and_ti_checkpoint(
     logger: logging.Logger,
     checkpoint_tracker: CheckpointTracker,
     lora_checkpoint_format: Literal["invoke_peft", "kohya"],
+    callbacks: list[PipelineCallbacks] | None,
 ):
     # Prune checkpoints and get new checkpoint path.
     num_pruned = checkpoint_tracker.prune(1)
     if num_pruned > 0:
         logger.info(f"Pruned {num_pruned} checkpoint(s).")
     save_path = checkpoint_tracker.get_path(epoch=epoch, step=step)
+
+    training_checkpoint = TrainingCheckpoint(models=[], epoch=epoch, step=step)
 
     if lora_checkpoint_format == "invoke_peft":
         save_sdxl_peft_checkpoint(
@@ -72,6 +76,7 @@ def _save_sdxl_lora_and_ti_checkpoint(
             text_encoder_1=text_encoder_1 if config.train_text_encoder else None,
             text_encoder_2=text_encoder_2 if config.train_text_encoder else None,
         )
+        training_checkpoint.models.append(ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_LORA_PEFT))
     elif lora_checkpoint_format == "kohya":
         save_sdxl_kohya_checkpoint(
             Path(save_path) / "lora.safetensors",
@@ -79,6 +84,7 @@ def _save_sdxl_lora_and_ti_checkpoint(
             text_encoder_1=text_encoder_1 if config.train_text_encoder else None,
             text_encoder_2=text_encoder_2 if config.train_text_encoder else None,
         )
+        training_checkpoint.models.append(ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_LORA_KOHYA))
     else:
         raise ValueError(f"Unsupported lora_checkpoint_format: '{lora_checkpoint_format}'.")
 
@@ -99,9 +105,16 @@ def _save_sdxl_lora_and_ti_checkpoint(
             "clip_g": learned_embeds_2.detach().cpu(),
         }
         save_state_dict(learned_embeds_dict, ti_checkpoint_path)
+        training_checkpoint.models.append(
+            ModelCheckpoint(path=ti_checkpoint_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)
+        )
+
+    if callbacks is not None:
+        for cb in callbacks:
+            cb.on_save_checkpoint(training_checkpoint)
 
 
-def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
+def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCallbacks] | None = None):  # noqa: C901
     # Give a clear error message if an unsupported base model was chosen.
     # TODO(ryan): Update this check to work with single-file SD checkpoints.
     # check_base_model_version(
@@ -382,6 +395,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                 logger=logger,
                 checkpoint_tracker=checkpoint_tracker,
                 lora_checkpoint_format=config.lora_checkpoint_format,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 
@@ -402,6 +416,7 @@ def train(config: SdxlLoraAndTextualInversionConfig):  # noqa: C901
                 unet=unet,
                 config=config,
                 logger=logger,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -76,7 +76,7 @@ def _save_sdxl_lora_and_ti_checkpoint(
             text_encoder_1=text_encoder_1 if config.train_text_encoder else None,
             text_encoder_2=text_encoder_2 if config.train_text_encoder else None,
         )
-        training_checkpoint.models.append(ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_LORA_PEFT))
+        training_checkpoint.models.append(ModelCheckpoint(file_path=save_path, model_type=ModelType.SDXL_LORA_PEFT))
     elif lora_checkpoint_format == "kohya":
         save_sdxl_kohya_checkpoint(
             Path(save_path) / "lora.safetensors",
@@ -84,7 +84,7 @@ def _save_sdxl_lora_and_ti_checkpoint(
             text_encoder_1=text_encoder_1 if config.train_text_encoder else None,
             text_encoder_2=text_encoder_2 if config.train_text_encoder else None,
         )
-        training_checkpoint.models.append(ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_LORA_KOHYA))
+        training_checkpoint.models.append(ModelCheckpoint(file_path=save_path, model_type=ModelType.SDXL_LORA_KOHYA))
     else:
         raise ValueError(f"Unsupported lora_checkpoint_format: '{lora_checkpoint_format}'.")
 
@@ -106,7 +106,7 @@ def _save_sdxl_lora_and_ti_checkpoint(
         }
         save_state_dict(learned_embeds_dict, ti_checkpoint_path)
         training_checkpoint.models.append(
-            ModelCheckpoint(path=ti_checkpoint_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)
+            ModelCheckpoint(file_path=ti_checkpoint_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)
         )
 
     if callbacks is not None:

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -82,7 +82,7 @@ def _save_ti_embeddings(
         for cb in callbacks:
             cb.on_save_checkpoint(
                 TrainingCheckpoint(
-                    models=[ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)],
+                    models=[ModelCheckpoint(file_path=save_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)],
                     epoch=epoch,
                     step=step,
                 )

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -32,6 +32,7 @@ from invoke_training._shared.stable_diffusion.textual_inversion import (
     restore_original_embeddings,
 )
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
+from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion_xl.lora.train import cache_vae_outputs, train_forward
 from invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.config import (
     SdxlLoraAndTextualInversionConfig,
@@ -49,6 +50,7 @@ def _save_ti_embeddings(
     accelerator: Accelerator,
     logger: logging.Logger,
     checkpoint_tracker: CheckpointTracker,
+    callbacks: list[PipelineCallbacks] | None,
 ):
     """Save a Textual Inversion SDXL checkpoint. Old checkpoints are deleted if necessary to respect the
     checkpoint_tracker limits.
@@ -75,6 +77,16 @@ def _save_ti_embeddings(
     }
 
     save_state_dict(learned_embeds_dict, save_path)
+
+    if callbacks is not None:
+        for cb in callbacks:
+            cb.on_save_checkpoint(
+                TrainingCheckpoint(
+                    models=[ModelCheckpoint(path=save_path, model_type=ModelType.SDXL_TEXTUAL_INVERSION)],
+                    epoch=epoch,
+                    step=step,
+                )
+            )
 
 
 def _initialize_placeholder_tokens(
@@ -145,7 +157,7 @@ def _initialize_placeholder_tokens(
     return placeholder_tokens_1, placeholder_token_ids_1, placeholder_token_ids_2
 
 
-def train(config: SdxlTextualInversionConfig):  # noqa: C901
+def train(config: SdxlTextualInversionConfig, callbacks: list[PipelineCallbacks] | None = None):  # noqa: C901
     # Create a timestamped directory for all outputs.
     out_dir = os.path.join(config.base_output_dir, f"{time.time()}")
     ckpt_dir = os.path.join(out_dir, "checkpoints")
@@ -346,6 +358,7 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                 accelerator=accelerator,
                 logger=logger,
                 checkpoint_tracker=checkpoint_tracker,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 
@@ -366,6 +379,7 @@ def train(config: SdxlTextualInversionConfig):  # noqa: C901
                 unet=unet,
                 config=config,
                 logger=logger,
+                callbacks=callbacks,
             )
         accelerator.wait_for_everyone()
 

--- a/src/invoke_training/scripts/invoke_train.py
+++ b/src/invoke_training/scripts/invoke_train.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import yaml
 from pydantic import TypeAdapter
 
-from invoke_training._shared.tools.invoke_train import train
 from invoke_training.config.pipeline_config import PipelineConfig
+from invoke_training.pipelines.invoke_train import train
 
 
 def parse_args():


### PR DESCRIPTION
This PR adds support for two callback slots when calling a pipeline via the API:
- on_save_checkpoint(self, checkpoint: TrainingCheckpoint)
- on_save_validation_images(self, images: ValidationImages)

- [x] Change target branch to main before merging