### PR TITLE
Add `keep_in_memory` option to ImageCaptionJsonlDataset

### DIFF
--- a/src/invoke_training/_shared/data/datasets/build_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/build_dataset.py
@@ -26,7 +26,10 @@ def build_hf_hub_image_caption_dataset(config: HFHubImageCaptionDatasetConfig) -
 
 def build_image_caption_jsonl_dataset(config: ImageCaptionJsonlDatasetConfig) -> HFImageCaptionDataset:
     return ImageCaptionJsonlDataset(
-        jsonl_path=config.jsonl_path, image_column=config.image_column, caption_column=config.caption_column
+        jsonl_path=config.jsonl_path,
+        image_column=config.image_column,
+        caption_column=config.caption_column,
+        keep_in_memory=config.keep_in_memory,
     )
 
 

--- a/src/invoke_training/config/data/dataset_config.py
+++ b/src/invoke_training/config/data/dataset_config.py
@@ -44,6 +44,12 @@ class ImageCaptionJsonlDatasetConfig(ConfigBaseModel):
     """The name of the dataset column that contains captions.
     """
 
+    keep_in_memory: bool = False
+    """If `True`, load all images into memory on initialization so that they can be accessed quickly. If `False`, images
+    are loaded from disk each time they are accessed. Setting to `True` improves performance for datasets that are small
+    enough to be kept in memory.
+    """
+
 
 class ImageDirDatasetConfig(ConfigBaseModel):
     type: Literal["IMAGE_DIR_DATASET"] = "IMAGE_DIR_DATASET"

--- a/src/invoke_training/ui/config_groups/dataset_config_group.py
+++ b/src/invoke_training/ui/config_groups/dataset_config_group.py
@@ -80,6 +80,12 @@ class ImageCaptionJsonlDatasetConfigGroup(UIConfigElement):
             info="The name of the field in the `.jsonl` containing image captions.",
             interactive=True,
         )
+        self.keep_in_memory = gr.Checkbox(
+            label="keep_in_memory",
+            info="If True, the entire dataset will be kept in RAM. This increases speed for small datasets at the "
+            "cost of higher RAM usage.",
+            interactive=True,
+        )
 
     def update_ui_components_with_config_data(
         self, config: ImageCaptionJsonlDatasetConfig | None
@@ -92,6 +98,7 @@ class ImageCaptionJsonlDatasetConfigGroup(UIConfigElement):
             self.jsonl_path: config.jsonl_path,
             self.image_column: config.image_column,
             self.caption_column: config.caption_column,
+            self.keep_in_memory: config.keep_in_memory,
         }
 
     def update_config_with_ui_component_data(
@@ -104,6 +111,7 @@ class ImageCaptionJsonlDatasetConfigGroup(UIConfigElement):
             jsonl_path=ui_data.pop(self.jsonl_path),
             image_column=ui_data.pop(self.image_column),
             caption_column=ui_data.pop(self.caption_column),
+            keep_in_memory=ui_data.pop(self.keep_in_memory),
         )
         return new_config
 

--- a/tests/invoke_training/_shared/data/datasets/test_image_caption_jsonl_dataset.py
+++ b/tests/invoke_training/_shared/data/datasets/test_image_caption_jsonl_dataset.py
@@ -23,6 +23,18 @@ def test_image_caption_jsonl_dataset_getitem(image_caption_jsonl):  # noqa: F811
     assert example["caption"] == "caption 0"
 
 
+def test_image_caption_jsonl_dataset_keep_in_memory(image_caption_jsonl):  # noqa: F811
+    dataset = ImageCaptionJsonlDataset(str(image_caption_jsonl), keep_in_memory=True)
+
+    example = dataset[0]
+
+    assert set(example.keys()) == {"image", "id", "caption"}
+    assert isinstance(example["image"], PIL.Image.Image)
+    assert example["image"].mode == "RGB"
+    assert example["id"] == "0"
+    assert example["caption"] == "caption 0"
+
+
 def test_image_caption_jsonl_dataset_get_image_dimensions(image_caption_jsonl):  # noqa: F811
     dataset = ImageCaptionJsonlDataset(str(image_caption_jsonl))
 


### PR DESCRIPTION
Add `keep_in_memory` option to `ImageCaptionJsonlDataset`. This improves data loading performance for small datasets that can be held in RAM.