### PR TITLE
Remove xformers from the required dependencies list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+"xformers" = ["xformers>=0.0.23; sys_platform!='darwin'"]
+
 "test" = [
     "mkdocs",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "tqdm",
     "transformers~=4.36.0",
     "uvicorn[standard]",
-    "xformers>=0.0.23",
 ]
 
 [project.optional-dependencies]

--- a/src/invoke_training/_shared/utils/import_xformers.py
+++ b/src/invoke_training/_shared/utils/import_xformers.py
@@ -4,5 +4,5 @@ def import_xformers():
     except ImportError:
         raise ImportError(
             "xformers is not installed. Either set `xformers = False` in your training config, or install it using "
-            "`pip install xformers>=0.0.23`."
+            '`pip install ".[xformers]"`.'
         )

--- a/src/invoke_training/_shared/utils/import_xformers.py
+++ b/src/invoke_training/_shared/utils/import_xformers.py
@@ -1,0 +1,8 @@
+def import_xformers():
+    try:
+        import xformers  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "xformers is not installed. Either set `xformers = False` in your training config, or install it using "
+            "`pip install xformers>=0.0.23`."
+        )

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -234,7 +235,7 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[Pipe
     ref_unet = copy.deepcopy(unet)
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         # TODO(ryand): There is a known issue if xformers is enabled when training in mixed precision where xformers
         # will fail because Q, K, V have different dtypes.

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -9,7 +9,6 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -39,6 +38,7 @@ from invoke_training._shared.stable_diffusion.lora_checkpoint_utils import (
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sd
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sd
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.pipelines._experimental.sd_dpo_lora.config import SdDirectPreferenceOptimizationLoraConfig
 from invoke_training.pipelines.callbacks import PipelineCallbacks
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_text_encoder_outputs

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Literal, Optional, Union
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -295,7 +296,7 @@ def train(config: SdLoraConfig, callbacks: list[PipelineCallbacks] | None = None
     )
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         # TODO(ryand): There is a known issue if xformers is enabled when training in mixed precision where xformers
         # will fail because Q, K, V have different dtypes.

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 from typing import Literal, Optional, Union
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -40,6 +39,7 @@ from invoke_training._shared.stable_diffusion.min_snr_weighting import compute_s
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sd
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sd
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.config.data.data_loader_config import DreamboothSDDataLoaderConfig, ImageCaptionSDDataLoaderConfig
 from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion.lora.config import SdLoraConfig

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import time
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import torch
 from accelerate import Accelerator
 from accelerate.utils import set_seed
@@ -189,7 +190,7 @@ def train(config: SdTextualInversionConfig, callbacks: list[PipelineCallbacks] |
         text_encoder.gradient_checkpointing_enable()
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         unet.enable_xformers_memory_efficient_attention()
         vae.enable_xformers_memory_efficient_attention()

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 import time
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import torch
 from accelerate import Accelerator
 from accelerate.utils import set_seed
@@ -33,6 +32,7 @@ from invoke_training._shared.stable_diffusion.textual_inversion import (
     restore_original_embeddings,
 )
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sd
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_vae_outputs, train_forward
 from invoke_training.pipelines.stable_diffusion.textual_inversion.config import SdTextualInversionConfig

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Literal, Optional, Union
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -366,7 +367,7 @@ def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = No
     )
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         # TODO(ryand): There is a known issue if xformers is enabled when training in mixed precision where xformers
         # will fail because Q, K, V have different dtypes.

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 from typing import Literal, Optional, Union
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -42,6 +41,7 @@ from invoke_training._shared.stable_diffusion.min_snr_weighting import compute_s
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training._shared.stable_diffusion.tokenize_captions import tokenize_captions
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.config.data.data_loader_config import DreamboothSDDataLoaderConfig, ImageCaptionSDDataLoaderConfig
 from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion.lora.train import cache_vae_outputs

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -39,6 +38,7 @@ from invoke_training._shared.stable_diffusion.lora_checkpoint_utils import (
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sdxl
 from invoke_training._shared.stable_diffusion.textual_inversion import restore_original_embeddings
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion_xl.lora.train import train_forward
 from invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.config import (

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import peft
 import torch
 import torch.utils.data
@@ -158,7 +159,7 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
     )
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         # TODO(ryand): There is a known issue if xformers is enabled when training in mixed precision where xformers
         # will fail because Q, K, V have different dtypes.

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 import time
 
-from invoke_training._shared.utils.import_xformers import import_xformers
 import torch
 import torch.utils.data
 from accelerate import Accelerator
@@ -33,6 +32,7 @@ from invoke_training._shared.stable_diffusion.textual_inversion import (
     restore_original_embeddings,
 )
 from invoke_training._shared.stable_diffusion.validation import generate_validation_images_sdxl
+from invoke_training._shared.utils.import_xformers import import_xformers
 from invoke_training.pipelines.callbacks import ModelCheckpoint, ModelType, PipelineCallbacks, TrainingCheckpoint
 from invoke_training.pipelines.stable_diffusion_xl.lora.train import cache_vae_outputs, train_forward
 from invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.config import (

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import time
 
+from invoke_training._shared.utils.import_xformers import import_xformers
 import torch
 import torch.utils.data
 from accelerate import Accelerator
@@ -219,7 +220,7 @@ def train(config: SdxlTextualInversionConfig, callbacks: list[PipelineCallbacks]
             te.gradient_checkpointing_enable()
 
     if config.xformers:
-        import xformers  # noqa: F401
+        import_xformers()
 
         unet.enable_xformers_memory_efficient_attention()
         vae.enable_xformers_memory_efficient_attention()

--- a/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_pickapic_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_pickapic_1x24gb.yaml
@@ -27,7 +27,6 @@ data_loader:
 model: runwayml/stable-diffusion-v1-5
 gradient_accumulation_steps: 2
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 max_train_steps: 5000
 save_every_n_epochs: 1

--- a/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_refinement_pokemon_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_refinement_pokemon_1x24gb.yaml
@@ -27,7 +27,6 @@ model: runwayml/stable-diffusion-v1-5
 initial_lora: output/sd_lora_pokemon/1704824279.2765746/checkpoint_epoch-00000003
 gradient_accumulation_steps: 2
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 max_train_steps: 5000
 save_every_n_epochs: 10

--- a/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
@@ -41,7 +41,6 @@ data_loader:
 model: runwayml/stable-diffusion-v1-5
 gradient_accumulation_steps: 1
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 
 max_train_epochs: 15

--- a/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
@@ -39,7 +39,6 @@ initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
 mixed_precision: fp16
-xformers: True
 gradient_checkpointing: True
 
 max_train_steps: 2000

--- a/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
@@ -35,7 +35,6 @@ initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 
 max_train_steps: 2000

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
@@ -43,7 +43,6 @@ model: stabilityai/stable-diffusion-xl-base-1.0
 vae_model: madebyollin/sdxl-vae-fp16-fix
 gradient_accumulation_steps: 1
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 
 max_train_epochs: 16

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
@@ -47,7 +47,6 @@ cache_text_encoder_outputs: True
 enable_cpu_offload_during_validation: True
 gradient_accumulation_steps: 4
 mixed_precision: fp16
-xformers: False
 gradient_checkpointing: True
 
 max_train_epochs: 6

--- a/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
@@ -35,7 +35,6 @@ initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
 mixed_precision: fp16
-xformers: True
 gradient_checkpointing: True
 
 max_train_steps: 2000


### PR DESCRIPTION
The installation of xformers causes issues on some platforms. At this point, most of the xformers optimizations have been incorporated directly into torch. The only reason we are keeping it around at all is because I have heard rumours that it still offers a benefit on some older GPUs.

After this PR we...:
- do not install xformers by default
- disable xformers in all of the sample configs
- provide a helpful error if someone enables xformers, but it is not installed