### PR TITLE
Add Docker files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG PYTHON_VERSION=3
+FROM python:${PYTHON_VERSION}-slim as base
+
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/home/appuser" \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    appuser
+
+# Copy the source code into the container.
+COPY src/ src/
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
+# Leverage a bind mount to requirements.txt to avoid having to copy them into
+# into this layer.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    python -m pip install -e ".[test]" --extra-index-url https://download.pytorch.org/whl/cu121
+
+# Switch to the non-privileged user to run the application.
+USER appuser
+
+# Expose the port that the application listens on.
+EXPOSE 8000
+
+# Run the application.
+CMD invoke-train-ui --host 0.0.0.0 --port 8000

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,8 +8,6 @@ services:
       - ./sample_data:/app/sample_data
       - ./output:/app/output
       - ./data:/home/appuser
-    networks:
-      - internal
     deploy:
       resources:
         reservations:
@@ -22,12 +20,7 @@ services:
     build:
         context: .
     ports:
-      - 8002:8001
+      - 8001:8001
     volumes:
       - ./output:/app/output
-    networks:
-      - internal
     command: tensorboard --logdir output/ --bind_all --port 8001
-        
-networks:
-    internal:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   server:
+    image: invokeai-training
     build:
       context: .
     ports:
@@ -17,6 +18,7 @@ services:
               capabilities: [gpu]
   
   tensorboard:
+    image: invokeai-training
     build:
         context: .
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,33 @@
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8000:8000
+    volumes:
+      - ./sample_data:/app/sample_data
+      - ./output:/app/output
+      - ./data:/home/appuser
+    networks:
+      - internal
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+  
+  tensorboard:
+    build:
+        context: .
+    ports:
+      - 8002:8001
+    volumes:
+      - ./output:/app/output
+    networks:
+      - internal
+    command: tensorboard --logdir output/ --bind_all --port 8001
+        
+networks:
+    internal:


### PR DESCRIPTION
This PR adds the required files to quickly setup the training UI and Tensorboard with Docker. It is based on the Docker template for Python apps, which is where the comments come from (can be removed if desired). 

To run, you need the fully cloned git repo. Workfiles (output, sample_data, cache) are currently bindmounted next to the compose file and might therefor clash with the git repo. I've done this since access to these folders is easier than to volumes. To prevent issues, the three folders could be added to the .gitignore. If this approach is unliked, I can also refactor it to a structure like this:
```
invoke-training/
|- compose.yaml
|- repo/
  |- git repo cloned into here
|- output/
|- sample_data/
|- cache/
```
which would imply making the user manually create / download the compose file instead of git cloning. Let me know if you have a preference in this regard.

GPU integration is done the same way it's done for InvokeAI. The training UI and Tensorboard are executed on neighbouring ports for convenience. 

If you're ready to accept the PR, I can also add usage instructions to the README / docs if desired. 