### PR TITLE
Log a warning for long initializer_token

### DIFF
--- a/src/invoke_training/_shared/stable_diffusion/textual_inversion.py
+++ b/src/invoke_training/_shared/stable_diffusion/textual_inversion.py
@@ -1,3 +1,5 @@
+import logging
+
 import torch
 from accelerate import Accelerator
 from transformers import CLIPTextModel, CLIPTokenizer, PreTrainedTokenizer
@@ -69,14 +71,17 @@ def initialize_placeholder_tokens_from_initializer_token(
     initializer_token: str,
     placeholder_token: str,
     num_vectors: int,
+    logger: logging.Logger,
 ) -> tuple[list[str], list[int]]:
     # Convert the initializer_token to a token id.
     initializer_token_ids = tokenizer.encode(initializer_token, add_special_tokens=False)
     if len(initializer_token_ids) > 1:
-        raise ValueError(
-            f"The initializer_token '{initializer_token}' gets tokenized to {len(initializer_token_ids)} tokens."
-            " Choose a different initializer that maps to a single token."
+        logger.warning(
+            f"The initializer_token '{initializer_token}' gets tokenized to {len(initializer_token_ids)} tokens. "
+            "Only the first token will be used. It is recommended to choose a different initializer_token that maps to "
+            "a single token."
         )
+
     initializer_token_id = initializer_token_ids[0]
 
     # Expand the tokenizer / text_encoder to include the placeholder tokens.

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -81,6 +81,7 @@ def _initialize_placeholder_tokens(
     config: SdTextualInversionConfig,
     tokenizer: CLIPTokenizer,
     text_encoder: PreTrainedTokenizer,
+    logger: logging.Logger,
 ) -> tuple[list[str], list[int]]:
     """Prepare the tokenizer and text_encoder for TI training.
 
@@ -109,6 +110,7 @@ def _initialize_placeholder_tokens(
             initializer_token=config.initializer_token,
             placeholder_token=config.placeholder_token,
             num_vectors=config.num_vectors,
+            logger=logger,
         )
     elif config.initial_embedding_file is not None:
         placeholder_tokens, placeholder_token_ids = initialize_placeholder_tokens_from_initial_embedding(
@@ -167,7 +169,7 @@ def train(config: SdTextualInversionConfig, callbacks: list[PipelineCallbacks] |
     )
 
     placeholder_tokens, placeholder_token_ids = _initialize_placeholder_tokens(
-        config=config, tokenizer=tokenizer, text_encoder=text_encoder
+        config=config, tokenizer=tokenizer, text_encoder=text_encoder, logger=logger
     )
     logger.info(f"Initialized {len(placeholder_tokens)} placeholder tokens: {placeholder_tokens}.")
 

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -231,6 +231,7 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
             tokenizer_2=tokenizer_2,
             text_encoder_1=text_encoder_1,
             text_encoder_2=text_encoder_2,
+            logger=logger,
         )
         logger.info(f"Initialized {len(placeholder_tokens)} placeholder tokens: {placeholder_tokens}.")
 

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -96,6 +96,7 @@ def _initialize_placeholder_tokens(
     tokenizer_2: CLIPTokenizer,
     text_encoder_1: PreTrainedTokenizer,
     text_encoder_2: PreTrainedTokenizer,
+    logger: logging.Logger,
 ) -> tuple[list[str], list[int], list[int]]:
     """Prepare the tokenizers and text_encoders for TI training.
 
@@ -125,6 +126,7 @@ def _initialize_placeholder_tokens(
             initializer_token=config.initializer_token,
             placeholder_token=config.placeholder_token,
             num_vectors=config.num_vectors,
+            logger=logger,
         )
         placeholder_tokens_2, placeholder_token_ids_2 = initialize_placeholder_tokens_from_initializer_token(
             tokenizer=tokenizer_2,
@@ -132,6 +134,7 @@ def _initialize_placeholder_tokens(
             initializer_token=config.initializer_token,
             placeholder_token=config.placeholder_token,
             num_vectors=config.num_vectors,
+            logger=logger,
         )
     elif getattr(config, "initial_embedding_file", None) is not None:
         # TODO(ryan)
@@ -197,6 +200,7 @@ def train(config: SdxlTextualInversionConfig, callbacks: list[PipelineCallbacks]
         tokenizer_2=tokenizer_2,
         text_encoder_1=text_encoder_1,
         text_encoder_2=text_encoder_2,
+        logger=logger,
     )
     logger.info(f"Initialized {len(placeholder_tokens)} placeholder tokens: {placeholder_tokens}.")
 

--- a/tests/invoke_training/_shared/stable_diffusion/test_textual_inversion.py
+++ b/tests/invoke_training/_shared/stable_diffusion/test_textual_inversion.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,7 @@ def test_initialize_placeholder_tokens_from_initializer_token():
         initializer_token=initializer_token,
         placeholder_token="dog_placeholder",
         num_vectors=num_vectors,
+        logger=logging.getLogger(),
     )
 
     assert len(placeholder_tokens) == num_vectors


### PR DESCRIPTION
Log a warning rather than raising an error when `initializer_token` gets tokenized to multiple tokens.