### PR TITLE
Add support for fp16 and bf16 training without mixed_precision

### DIFF
--- a/src/invoke_training/_shared/accelerator/accelerator_utils.py
+++ b/src/invoke_training/_shared/accelerator/accelerator_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Literal
 
 import datasets
 import diffusers
@@ -89,3 +90,14 @@ def get_mixed_precision_dtype(accelerator: Accelerator):
     else:
         raise NotImplementedError(f"mixed_precision mode '{accelerator.mixed_precision}' is not yet supported.")
     return weight_dtype
+
+
+def get_dtype_from_str(dtype_str: Literal["float16", "bfloat16", "float32"]) -> torch.dtype:
+    if dtype_str == "float16":
+        return torch.float16
+    elif dtype_str == "bfloat16":
+        return torch.bfloat16
+    elif dtype_str == "float32":
+        return torch.float32
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype_str}")

--- a/src/invoke_training/_shared/stable_diffusion/model_loading_utils.py
+++ b/src/invoke_training/_shared/stable_diffusion/model_loading_utils.py
@@ -2,6 +2,7 @@ import os
 import typing
 from enum import Enum
 
+import torch
 from diffusers import (
     AutoencoderKL,
     DDPMScheduler,
@@ -56,6 +57,7 @@ def load_models_sd(
     model_name_or_path: str,
     hf_variant: str | None = None,
     base_embeddings: dict[str, str] = None,
+    dtype: torch.dtype | None = None,
 ) -> tuple[CLIPTokenizer, DDPMScheduler, CLIPTextModel, AutoencoderKL, UNet2DConditionModel]:
     """Load all models required for training from disk, transfer them to the
     target training device and cast their weight dtypes.
@@ -88,6 +90,11 @@ def load_models_sd(
     vae.requires_grad_(False)
     unet.requires_grad_(False)
 
+    if dtype is not None:
+        text_encoder = text_encoder.to(dtype=dtype)
+        vae = vae.to(dtype=dtype)
+        unet = unet.to(dtype=dtype)
+
     # Put models in 'eval' mode.
     text_encoder.eval()
     vae.eval()
@@ -101,6 +108,7 @@ def load_models_sdxl(
     hf_variant: str | None = None,
     vae_model: str | None = None,
     base_embeddings: dict[str, str] = None,
+    dtype: torch.dtype | None = None,
 ) -> tuple[
     CLIPTokenizer,
     CLIPTokenizer,
@@ -158,6 +166,12 @@ def load_models_sdxl(
     text_encoder_2.requires_grad_(False)
     vae.requires_grad_(False)
     unet.requires_grad_(False)
+
+    if dtype is not None:
+        text_encoder_1 = text_encoder_1.to(dtype=dtype)
+        text_encoder_2 = text_encoder_2.to(dtype=dtype)
+        vae = vae.to(dtype=dtype)
+        unet = unet.to(dtype=dtype)
 
     # Put models in 'eval' mode.
     text_encoder_1.eval()

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/config.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/config.py
@@ -150,20 +150,28 @@ class SdDirectPreferenceOptimizationLoraConfig(BasePipelineConfig):
     Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     """
 
-    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
-    """The mixed precision mode to use.
-
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
 
     Recommendations:
 
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
 
-    This value is passed to Hugging Face Accelerate. See `accelerate.Accelerator` for more details.
+    See also [`mixed_precision`][invoke_training.pipelines._experimental.sd_dpo_lora.config.SdDirectPreferenceOptimizationLoraConfig.mixed_precision].
+    """  # noqa: E501
+
+    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
+    """The mixed precision mode to use.
+
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
+
+    This value is passed to Hugging Face Accelerate. See
+    [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)
+    for more details.
     """  # noqa: E501
 
     xformers: bool = False

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -19,7 +19,7 @@ from tqdm.auto import tqdm
 from transformers import CLIPTextModel, CLIPTokenizer
 
 from invoke_training._shared.accelerator.accelerator_utils import (
-    get_mixed_precision_dtype,
+    get_dtype_from_str,
     initialize_accelerator,
     initialize_logging,
 )
@@ -225,7 +225,7 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[Pipe
     with open(os.path.join(out_dir, "config.json"), "w") as f:
         json.dump(config.dict(), f, indent=2, default=str)
 
-    weight_dtype = get_mixed_precision_dtype(accelerator)
+    weight_dtype = get_dtype_from_str(config.weight_dtype)
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
@@ -352,11 +352,12 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[Pipe
     training_unet = prep_peft_model(unet, config.unet_learning_rate)
     training_text_encoder = prep_peft_model(text_encoder, config.text_encoder_learning_rate)
 
-    # Make sure all trainable params are in float32.
-    for trainable_model in all_trainable_models:
-        for param in trainable_model.parameters():
-            if param.requires_grad:
-                param.data = param.to(torch.float32)
+    # If mixed_precision is enabled, cast all trainable params to float32.
+    if config.mixed_precision != "no":
+        for trainable_model in all_trainable_models:
+            for param in trainable_model.parameters():
+                if param.requires_grad:
+                    param.data = param.to(torch.float32)
 
     if config.gradient_checkpointing:
         # We want to enable gradient checkpointing in the UNet regardless of whether it is being trained.

--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -229,7 +229,10 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[Pipe
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path=config.model, hf_variant=config.hf_variant, base_embeddings=config.base_embeddings
+        model_name_or_path=config.model,
+        hf_variant=config.hf_variant,
+        base_embeddings=config.base_embeddings,
+        dtype=weight_dtype,
     )
     ref_text_encoder = copy.deepcopy(text_encoder)
     ref_unet = copy.deepcopy(unet)

--- a/src/invoke_training/pipelines/stable_diffusion/lora/config.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/config.py
@@ -110,18 +110,24 @@ class SdLoraConfig(BasePipelineConfig):
     Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     """
 
-    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
-    """The mixed precision mode to use.
-
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
 
     Recommendations:
 
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
+
+    See also [`mixed_precision`][invoke_training.pipelines.stable_diffusion.lora.config.SdLoraConfig.mixed_precision].
+    """  # noqa: E501
+
+    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
+    """The mixed precision mode to use.
+
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
 
     This value is passed to Hugging Face Accelerate. See
     [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -292,7 +292,10 @@ def train(config: SdLoraConfig, callbacks: list[PipelineCallbacks] | None = None
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path=config.model, hf_variant=config.hf_variant, base_embeddings=config.base_embeddings
+        model_name_or_path=config.model,
+        hf_variant=config.hf_variant,
+        base_embeddings=config.base_embeddings,
+        dtype=weight_dtype,
     )
 
     if config.xformers:

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/config.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/config.py
@@ -116,18 +116,24 @@ class SdTextualInversionConfig(BasePipelineConfig):
     `train_batch_size` when training with limited VRAM.
     """
 
-    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
-    """The mixed precision mode to use.
-
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
 
     Recommendations:
 
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
+
+    See also [`mixed_precision`][invoke_training.pipelines.stable_diffusion.textual_inversion.config.SdTextualInversionConfig.mixed_precision].
+    """  # noqa: E501
+
+    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
+    """The mixed precision mode to use.
+
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
 
     This value is passed to Hugging Face Accelerate. See
     [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -13,7 +13,7 @@ from tqdm.auto import tqdm
 from transformers import CLIPTextModel, CLIPTokenizer, PreTrainedTokenizer
 
 from invoke_training._shared.accelerator.accelerator_utils import (
-    get_mixed_precision_dtype,
+    get_dtype_from_str,
     initialize_accelerator,
     initialize_logging,
 )
@@ -161,7 +161,7 @@ def train(config: SdTextualInversionConfig, callbacks: list[PipelineCallbacks] |
     with open(os.path.join(out_dir, "config.json"), "w") as f:
         json.dump(config.dict(), f, indent=2, default=str)
 
-    weight_dtype = get_mixed_precision_dtype(accelerator)
+    weight_dtype = get_dtype_from_str(config.weight_dtype)
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/config.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/config.py
@@ -110,18 +110,24 @@ class SdxlLoraConfig(BasePipelineConfig):
     Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     """
 
-    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
-    """The mixed precision mode to use.
-
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
 
     Recommendations:
 
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
+
+    See also [`mixed_precision`][invoke_training.pipelines.stable_diffusion_xl.lora.config.SdxlLoraConfig.mixed_precision].
+    """  # noqa: E501
+
+    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
+    """The mixed precision mode to use.
+
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
 
     This value is passed to Hugging Face Accelerate. See
     [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -364,6 +364,7 @@ def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = No
         hf_variant=config.hf_variant,
         vae_model=config.vae_model,
         base_embeddings=config.base_embeddings,
+        dtype=weight_dtype,
     )
 
     if config.xformers:

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -20,7 +20,7 @@ from tqdm.auto import tqdm
 from transformers import CLIPPreTrainedModel, CLIPTextModel, PreTrainedTokenizer
 
 from invoke_training._shared.accelerator.accelerator_utils import (
-    get_mixed_precision_dtype,
+    get_dtype_from_str,
     initialize_accelerator,
     initialize_logging,
 )
@@ -356,7 +356,7 @@ def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = No
     with open(os.path.join(out_dir, "config.json"), "w") as f:
         json.dump(config.dict(), f, indent=2, default=str)
 
-    weight_dtype = get_mixed_precision_dtype(accelerator)
+    weight_dtype = get_dtype_from_str(config.weight_dtype)
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
@@ -479,11 +479,12 @@ def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = No
             text_encoder_2, text_encoder_lora_config, lr=config.text_encoder_learning_rate
         )
 
-    # Make sure all trainable params are in float32.
-    for trainable_model in all_trainable_models:
-        for param in trainable_model.parameters():
-            if param.requires_grad:
-                param.data = param.to(torch.float32)
+    # If mixed_precision is enabled, cast all trainable params to float32.
+    if config.mixed_precision != "no":
+        for trainable_model in all_trainable_models:
+            for param in trainable_model.parameters():
+                if param.requires_grad:
+                    param.data = param.to(torch.float32)
 
     if config.gradient_checkpointing:
         # We want to enable gradient checkpointing in the UNet regardless of whether it is being trained.

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/config.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/config.py
@@ -143,19 +143,24 @@ class SdxlLoraAndTextualInversionConfig(BasePipelineConfig):
     """The number of gradient steps to accumulate before each weight update. This value is passed to Hugging Face
     Accelerate. This is an alternative to increasing the batch size when training with limited VRAM.
     """
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
+
+    Recommendations:
+
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
+
+    See also [`mixed_precision`][invoke_training.pipelines.stable_diffusion_xl.lora_and_textual_inversion.config.SdxlLoraAndTextualInversionConfig.mixed_precision].
+    """  # noqa: E501
 
     mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
     """The mixed precision mode to use.
 
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
-
-    Recommendations:
-
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
 
     This value is passed to Hugging Face Accelerate. See
     [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -18,7 +18,7 @@ from tqdm.auto import tqdm
 from transformers import CLIPTextModel
 
 from invoke_training._shared.accelerator.accelerator_utils import (
-    get_mixed_precision_dtype,
+    get_dtype_from_str,
     initialize_accelerator,
     initialize_logging,
 )
@@ -149,7 +149,7 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
     with open(os.path.join(out_dir, "config.json"), "w") as f:
         json.dump(config.dict(), f, indent=2, default=str)
 
-    weight_dtype = get_mixed_precision_dtype(accelerator)
+    weight_dtype = get_dtype_from_str(config.weight_dtype)
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
@@ -249,11 +249,12 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
             }
             trainable_param_groups.append(param_group)
 
-    # Make sure all trainable params are in float32.
-    for trainable_model in all_trainable_models:
-        for param in trainable_model.parameters():
-            if param.requires_grad:
-                param.data = param.to(torch.float32)
+    # If mixed_precision is enabled, cast all trainable params to float32.
+    if config.mixed_precision != "no":
+        for trainable_model in all_trainable_models:
+            for param in trainable_model.parameters():
+                if param.requires_grad:
+                    param.data = param.to(torch.float32)
 
     if config.gradient_checkpointing:
         # We want to enable gradient checkpointing in the UNet regardless of whether it is being trained.

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -102,8 +102,8 @@ def _save_sdxl_lora_and_ti_checkpoint(
             .weight[min(placeholder_token_ids_2) : max(placeholder_token_ids_2) + 1]
         )
         learned_embeds_dict = {
-            "clip_l": learned_embeds_1.detach().cpu(),
-            "clip_g": learned_embeds_2.detach().cpu(),
+            "clip_l": learned_embeds_1.detach().cpu().to(dtype=torch.float32),
+            "clip_g": learned_embeds_2.detach().cpu().to(dtype=torch.float32),
         }
         save_state_dict(learned_embeds_dict, ti_checkpoint_path)
         training_checkpoint.models.append(
@@ -156,6 +156,7 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
         model_name_or_path=config.model,
         hf_variant=config.hf_variant,
         vae_model=config.vae_model,
+        dtype=weight_dtype,
     )
 
     if config.xformers:

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/config.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/config.py
@@ -116,18 +116,24 @@ class SdxlTextualInversionConfig(BasePipelineConfig):
     `train_batch_size` when training with limited VRAM.
     """
 
-    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
-    """The mixed precision mode to use.
-
-    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified precision. The
-    trainable parameters are always kept in float32 precision to avoid issues with numerical stability.
+    weight_dtype: Literal["float32", "float16", "bfloat16"] = "bfloat16"
+    """All weights (trainable and fixed) will be cast to this precision. Lower precision dtypes require less VRAM, and
+    result in faster training, but are more prone to issues with numerical stability.
 
     Recommendations:
 
-    - `"no"`: Use this mode if you have plenty of VRAM available.
-    - `"bf16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
-    - `"fp16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
-    - `"fp8"`: You are likely to run into numerical stability issues with this mode. Only use this mode if you know what you are doing and are willing to work through some issues.
+    - `"float32"`: Use this mode if you have plenty of VRAM available.
+    - `"bfloat16"`: Use this mode if you have limited VRAM and a GPU that supports bfloat16.
+    - `"float16"`: Use this mode if you have limited VRAM and a GPU that does not support bfloat16.
+
+    See also [`mixed_precision`][invoke_training.pipelines.stable_diffusion_xl.textual_inversion.config.SdxlTextualInversionConfig.mixed_precision].
+    """  # noqa: E501
+
+    mixed_precision: Literal["no", "fp16", "bf16", "fp8"] = "no"
+    """The mixed precision mode to use.
+
+    If mixed precision is enabled, then all non-trainable parameters will be cast to the specified `weight_dtype`, and
+    trainable parameters are kept in float32 precision to avoid issues with numerical stability.
 
     This value is passed to Hugging Face Accelerate. See
     [`accelerate.Accelerator.mixed_precision`](https://huggingface.co/docs/accelerate/package_reference/accelerator#accelerate.Accelerator.mixed_precision)

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -14,7 +14,7 @@ from tqdm.auto import tqdm
 from transformers import CLIPPreTrainedModel, CLIPTextModel, CLIPTokenizer, PreTrainedTokenizer
 
 from invoke_training._shared.accelerator.accelerator_utils import (
-    get_mixed_precision_dtype,
+    get_dtype_from_str,
     initialize_accelerator,
     initialize_logging,
 )
@@ -187,7 +187,7 @@ def train(config: SdxlTextualInversionConfig, callbacks: list[PipelineCallbacks]
     with open(os.path.join(out_dir, "config.json"), "w") as f:
         json.dump(config.dict(), f, indent=2, default=str)
 
-    weight_dtype = get_mixed_precision_dtype(accelerator)
+    weight_dtype = get_dtype_from_str(config.weight_dtype)
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(

--- a/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_pickapic_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_pickapic_1x24gb.yaml
@@ -26,6 +26,7 @@ data_loader:
 # General
 model: runwayml/stable-diffusion-v1-5
 gradient_accumulation_steps: 2
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 max_train_steps: 5000

--- a/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_refinement_pokemon_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/_experimental/sd_dpo_lora_refinement_pokemon_1x24gb.yaml
@@ -26,6 +26,7 @@ data_loader:
 model: runwayml/stable-diffusion-v1-5
 initial_lora: output/sd_lora_pokemon/1704824279.2765746/checkpoint_epoch-00000003
 gradient_accumulation_steps: 2
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 max_train_steps: 5000

--- a/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
@@ -40,6 +40,7 @@ data_loader:
 # General
 model: runwayml/stable-diffusion-v1-5
 gradient_accumulation_steps: 1
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_lora_baroque_1x8gb.yaml
@@ -40,8 +40,7 @@ data_loader:
 # General
 model: runwayml/stable-diffusion-v1-5
 gradient_accumulation_steps: 1
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
 gradient_checkpointing: True
 
 max_train_epochs: 15

--- a/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
@@ -38,6 +38,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sd_textual_inversion_gnome_1x8gb.yaml
@@ -38,8 +38,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
 gradient_checkpointing: True
 
 max_train_steps: 2000

--- a/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
@@ -34,8 +34,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
 gradient_checkpointing: True
 
 max_train_steps: 2000

--- a/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_and_ti_gnome_1x24gb.yaml
@@ -34,6 +34,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
@@ -39,7 +39,6 @@ model: stabilityai/stable-diffusion-xl-base-1.0
 # vae_model: madebyollin/sdxl-vae-fp16-fix
 gradient_accumulation_steps: 1
 weight_dtype: bfloat16
-mixed_precision: "no"
 gradient_checkpointing: True
 cache_vae_outputs: True
 

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
@@ -17,11 +17,8 @@ seed: 1
 base_output_dir: output/baroque/sdxl_lora
 
 optimizer:
-  optimizer_type: Prodigy
-  learning_rate: 1.0
-  weight_decay: 0.01
-  use_bias_correction: True
-  safeguard_warmup: True
+  optimizer_type: AdamW
+  learning_rate: 1e-3
 
 data_loader:
   type: IMAGE_CAPTION_SD_DATA_LOADER
@@ -36,15 +33,15 @@ data_loader:
     end_dim: 1536
     divisible_by: 128
   caption_prefix: "A baroque painting of"
-  dataloader_num_workers: 4
 
 # General
 model: stabilityai/stable-diffusion-xl-base-1.0
-vae_model: madebyollin/sdxl-vae-fp16-fix
+# vae_model: madebyollin/sdxl-vae-fp16-fix
 gradient_accumulation_steps: 1
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
+mixed_precision: "no"
 gradient_checkpointing: True
+cache_vae_outputs: True
 
 max_train_epochs: 16
 save_every_n_epochs: 2

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x24gb.yaml
@@ -42,6 +42,7 @@ data_loader:
 model: stabilityai/stable-diffusion-xl-base-1.0
 vae_model: madebyollin/sdxl-vae-fp16-fix
 gradient_accumulation_steps: 1
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
@@ -46,8 +46,7 @@ train_text_encoder: False
 cache_text_encoder_outputs: True
 enable_cpu_offload_during_validation: True
 gradient_accumulation_steps: 4
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
 gradient_checkpointing: True
 
 max_train_epochs: 6

--- a/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_lora_baroque_1x8gb.yaml
@@ -46,6 +46,7 @@ train_text_encoder: False
 cache_text_encoder_outputs: True
 enable_cpu_offload_during_validation: True
 gradient_accumulation_steps: 4
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
@@ -34,8 +34,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
-weight_dtype: float16
-mixed_precision: fp16
+weight_dtype: bfloat16
 gradient_checkpointing: True
 
 max_train_steps: 2000

--- a/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
+++ b/src/invoke_training/sample_configs/sdxl_textual_inversion_gnome_1x24gb.yaml
@@ -34,6 +34,7 @@ placeholder_token: "bruce_the_gnome"
 initializer_token: "gnome"
 cache_vae_outputs: False
 gradient_accumulation_steps: 1
+weight_dtype: float16
 mixed_precision: fp16
 gradient_checkpointing: True
 

--- a/src/invoke_training/ui/config_groups/sd_lora_config_group.py
+++ b/src/invoke_training/ui/config_groups/sd_lora_config_group.py
@@ -67,11 +67,12 @@ class SdLoraConfigGroup(UIConfigElement):
                     interactive=True,
                 )
             with gr.Row():
-                self.mixed_precision = gr.Dropdown(
-                    label="Mixed Precision",
-                    info="The mixed precision training mode to used. Using a lower precision can speed up training and "
-                    "reduce memory usage, with a minor quality hit.",
-                    choices=get_typing_literal_options(SdLoraConfig, "mixed_precision"),
+                self.weight_dtype = gr.Dropdown(
+                    label="Weight Type",
+                    info="The precision of the model weights. Lower precision can speed up training and reduce memory, "
+                    "with increased risk of numerical stability issues. 'bfloat16' is recommended for most use cases "
+                    "if your GPU supports it.",
+                    choices=get_typing_literal_options(SdLoraConfig, "weight_dtype"),
                     interactive=True,
                 )
             with gr.Row():
@@ -188,7 +189,7 @@ class SdLoraConfigGroup(UIConfigElement):
             self.cache_vae_outputs: config.cache_vae_outputs,
             self.enable_cpu_offload_during_validation: config.enable_cpu_offload_during_validation,
             self.gradient_accumulation_steps: config.gradient_accumulation_steps,
-            self.mixed_precision: config.mixed_precision,
+            self.weight_dtype: config.weight_dtype,
             self.gradient_checkpointing: config.gradient_checkpointing,
             self.lora_rank_dim: config.lora_rank_dim,
             self.min_snr_gamma: config.min_snr_gamma,
@@ -228,7 +229,7 @@ class SdLoraConfigGroup(UIConfigElement):
         new_config.cache_vae_outputs = ui_data.pop(self.cache_vae_outputs)
         new_config.enable_cpu_offload_during_validation = ui_data.pop(self.enable_cpu_offload_during_validation)
         new_config.gradient_accumulation_steps = ui_data.pop(self.gradient_accumulation_steps)
-        new_config.mixed_precision = ui_data.pop(self.mixed_precision)
+        new_config.weight_dtype = ui_data.pop(self.weight_dtype)
         new_config.gradient_checkpointing = ui_data.pop(self.gradient_checkpointing)
         new_config.lora_rank_dim = ui_data.pop(self.lora_rank_dim)
         new_config.min_snr_gamma = ui_data.pop(self.min_snr_gamma)

--- a/src/invoke_training/ui/config_groups/sd_textual_inversion_config_group.py
+++ b/src/invoke_training/ui/config_groups/sd_textual_inversion_config_group.py
@@ -96,11 +96,12 @@ class SdTextualInversionConfigGroup(UIConfigElement):
                     interactive=True,
                 )
             with gr.Row():
-                self.mixed_precision = gr.Dropdown(
-                    label="Mixed Precision",
-                    info="The mixed precision training mode to used. Using a lower precision can speed up training and "
-                    "reduce memory usage, with a minor quality hit.",
-                    choices=get_typing_literal_options(SdTextualInversionConfig, "mixed_precision"),
+                self.weight_dtype = gr.Dropdown(
+                    label="Weight Type",
+                    info="The precision of the model weights. Lower precision can speed up training and reduce memory, "
+                    "with increased risk of numerical stability issues. 'bfloat16' is recommended for most use cases "
+                    "if your GPU supports it.",
+                    choices=get_typing_literal_options(SdTextualInversionConfig, "weight_dtype"),
                     interactive=True,
                 )
             with gr.Row():
@@ -189,7 +190,7 @@ class SdTextualInversionConfigGroup(UIConfigElement):
             self.cache_vae_outputs: config.cache_vae_outputs,
             self.enable_cpu_offload_during_validation: config.enable_cpu_offload_during_validation,
             self.gradient_accumulation_steps: config.gradient_accumulation_steps,
-            self.mixed_precision: config.mixed_precision,
+            self.weight_dtype: config.weight_dtype,
             self.gradient_checkpointing: config.gradient_checkpointing,
             self.min_snr_gamma: config.min_snr_gamma,
             self.validation_prompts: convert_pos_neg_prompts_to_ui_prompts(
@@ -227,7 +228,7 @@ class SdTextualInversionConfigGroup(UIConfigElement):
         new_config.cache_vae_outputs = ui_data.pop(self.cache_vae_outputs)
         new_config.enable_cpu_offload_during_validation = ui_data.pop(self.enable_cpu_offload_during_validation)
         new_config.gradient_accumulation_steps = ui_data.pop(self.gradient_accumulation_steps)
-        new_config.mixed_precision = ui_data.pop(self.mixed_precision)
+        new_config.weight_dtype = ui_data.pop(self.weight_dtype)
         new_config.gradient_checkpointing = ui_data.pop(self.gradient_checkpointing)
         new_config.min_snr_gamma = ui_data.pop(self.min_snr_gamma)
         new_config.num_validation_images_per_prompt = ui_data.pop(self.num_validation_images_per_prompt)

--- a/src/invoke_training/ui/config_groups/sdxl_lora_and_textual_inversion_config_group.py
+++ b/src/invoke_training/ui/config_groups/sdxl_lora_and_textual_inversion_config_group.py
@@ -104,11 +104,12 @@ class SdxlLoraAndTextualInversionConfigGroup(UIConfigElement):
                     interactive=True,
                 )
             with gr.Row():
-                self.mixed_precision = gr.Dropdown(
-                    label="Mixed Precision",
-                    info="The mixed precision training mode to used. Using a lower precision can speed up training and "
-                    "reduce memory usage, with a minor quality hit.",
-                    choices=get_typing_literal_options(SdxlLoraAndTextualInversionConfig, "mixed_precision"),
+                self.weight_dtype = gr.Dropdown(
+                    label="Weight Type",
+                    info="The precision of the model weights. Lower precision can speed up training and reduce memory, "
+                    "with increased risk of numerical stability issues. 'bfloat16' is recommended for most use cases "
+                    "if your GPU supports it.",
+                    choices=get_typing_literal_options(SdxlLoraAndTextualInversionConfig, "weight_dtype"),
                     interactive=True,
                 )
             with gr.Row():
@@ -230,7 +231,7 @@ class SdxlLoraAndTextualInversionConfigGroup(UIConfigElement):
             self.cache_vae_outputs: config.cache_vae_outputs,
             self.enable_cpu_offload_during_validation: config.enable_cpu_offload_during_validation,
             self.gradient_accumulation_steps: config.gradient_accumulation_steps,
-            self.mixed_precision: config.mixed_precision,
+            self.weight_dtype: config.weight_dtype,
             self.gradient_checkpointing: config.gradient_checkpointing,
             self.lora_rank_dim: config.lora_rank_dim,
             self.min_snr_gamma: config.min_snr_gamma,
@@ -278,7 +279,7 @@ class SdxlLoraAndTextualInversionConfigGroup(UIConfigElement):
         new_config.cache_vae_outputs = ui_data.pop(self.cache_vae_outputs)
         new_config.enable_cpu_offload_during_validation = ui_data.pop(self.enable_cpu_offload_during_validation)
         new_config.gradient_accumulation_steps = ui_data.pop(self.gradient_accumulation_steps)
-        new_config.mixed_precision = ui_data.pop(self.mixed_precision)
+        new_config.weight_dtype = ui_data.pop(self.weight_dtype)
         new_config.gradient_checkpointing = ui_data.pop(self.gradient_checkpointing)
         new_config.lora_rank_dim = ui_data.pop(self.lora_rank_dim)
         new_config.min_snr_gamma = ui_data.pop(self.min_snr_gamma)

--- a/src/invoke_training/ui/config_groups/sdxl_lora_config_group.py
+++ b/src/invoke_training/ui/config_groups/sdxl_lora_config_group.py
@@ -73,11 +73,12 @@ class SdxlLoraConfigGroup(UIConfigElement):
                     interactive=True,
                 )
             with gr.Row():
-                self.mixed_precision = gr.Dropdown(
-                    label="Mixed Precision",
-                    info="The mixed precision training mode to used. Using a lower precision can speed up training and "
-                    "reduce memory usage, with a minor quality hit.",
-                    choices=get_typing_literal_options(SdxlLoraConfig, "mixed_precision"),
+                self.weight_dtype = gr.Dropdown(
+                    label="Weight Type",
+                    info="The precision of the model weights. Lower precision can speed up training and reduce memory, "
+                    "with increased risk of numerical stability issues. 'bfloat16' is recommended for most use cases "
+                    "if your GPU supports it.",
+                    choices=get_typing_literal_options(SdxlLoraConfig, "weight_dtype"),
                     interactive=True,
                 )
             with gr.Row():
@@ -197,7 +198,7 @@ class SdxlLoraConfigGroup(UIConfigElement):
             self.cache_vae_outputs: config.cache_vae_outputs,
             self.enable_cpu_offload_during_validation: config.enable_cpu_offload_during_validation,
             self.gradient_accumulation_steps: config.gradient_accumulation_steps,
-            self.mixed_precision: config.mixed_precision,
+            self.weight_dtype: config.weight_dtype,
             self.gradient_checkpointing: config.gradient_checkpointing,
             self.lora_rank_dim: config.lora_rank_dim,
             self.min_snr_gamma: config.min_snr_gamma,
@@ -238,7 +239,7 @@ class SdxlLoraConfigGroup(UIConfigElement):
         new_config.cache_vae_outputs = ui_data.pop(self.cache_vae_outputs)
         new_config.enable_cpu_offload_during_validation = ui_data.pop(self.enable_cpu_offload_during_validation)
         new_config.gradient_accumulation_steps = ui_data.pop(self.gradient_accumulation_steps)
-        new_config.mixed_precision = ui_data.pop(self.mixed_precision)
+        new_config.weight_dtype = ui_data.pop(self.weight_dtype)
         new_config.gradient_checkpointing = ui_data.pop(self.gradient_checkpointing)
         new_config.lora_rank_dim = ui_data.pop(self.lora_rank_dim)
         new_config.min_snr_gamma = ui_data.pop(self.min_snr_gamma)

--- a/src/invoke_training/ui/config_groups/sdxl_textual_inversion_config_group.py
+++ b/src/invoke_training/ui/config_groups/sdxl_textual_inversion_config_group.py
@@ -102,11 +102,12 @@ class SdxlTextualInversionConfigGroup(UIConfigElement):
                     interactive=True,
                 )
             with gr.Row():
-                self.mixed_precision = gr.Dropdown(
-                    label="Mixed Precision",
-                    info="The mixed precision training mode to used. Using a lower precision can speed up training and "
-                    "reduce memory usage, with a minor quality hit.",
-                    choices=get_typing_literal_options(SdxlTextualInversionConfig, "mixed_precision"),
+                self.weight_dtype = gr.Dropdown(
+                    label="Weight Type",
+                    info="The precision of the model weights. Lower precision can speed up training and reduce memory, "
+                    "with increased risk of numerical stability issues. 'bfloat16' is recommended for most use cases "
+                    "if your GPU supports it.",
+                    choices=get_typing_literal_options(SdxlTextualInversionConfig, "weight_dtype"),
                     interactive=True,
                 )
             with gr.Row():
@@ -196,7 +197,7 @@ class SdxlTextualInversionConfigGroup(UIConfigElement):
             self.cache_vae_outputs: config.cache_vae_outputs,
             self.enable_cpu_offload_during_validation: config.enable_cpu_offload_during_validation,
             self.gradient_accumulation_steps: config.gradient_accumulation_steps,
-            self.mixed_precision: config.mixed_precision,
+            self.weight_dtype: config.weight_dtype,
             self.gradient_checkpointing: config.gradient_checkpointing,
             self.min_snr_gamma: config.min_snr_gamma,
             self.validation_prompts: convert_pos_neg_prompts_to_ui_prompts(
@@ -235,7 +236,7 @@ class SdxlTextualInversionConfigGroup(UIConfigElement):
         new_config.cache_vae_outputs = ui_data.pop(self.cache_vae_outputs)
         new_config.enable_cpu_offload_during_validation = ui_data.pop(self.enable_cpu_offload_during_validation)
         new_config.gradient_accumulation_steps = ui_data.pop(self.gradient_accumulation_steps)
-        new_config.mixed_precision = ui_data.pop(self.mixed_precision)
+        new_config.weight_dtype = ui_data.pop(self.weight_dtype)
         new_config.gradient_checkpointing = ui_data.pop(self.gradient_checkpointing)
         new_config.min_snr_gamma = ui_data.pop(self.min_snr_gamma)
         new_config.num_validation_images_per_prompt = ui_data.pop(self.num_validation_images_per_prompt)


### PR DESCRIPTION
This PR adds the `weight_dtype` config option to all pipelines. This can be used to train in float16 or bfloat16 precision without enabling acclerate's automatic mixed precision features. This is desired, because automatic mixed precision can be significantly slower in some cases.