### PR TITLE
Try fallback variants when we fail to load an HF model with the initial hf_variant.

### DIFF
--- a/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
+++ b/src/invoke_training/pipelines/_experimental/sd_dpo_lora/train.py
@@ -229,6 +229,7 @@ def train(config: SdDirectPreferenceOptimizationLoraConfig, callbacks: list[Pipe
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        logger=logger,
         model_name_or_path=config.model,
         hf_variant=config.hf_variant,
         base_embeddings=config.base_embeddings,

--- a/src/invoke_training/pipelines/stable_diffusion/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/lora/train.py
@@ -292,6 +292,7 @@ def train(config: SdLoraConfig, callbacks: list[PipelineCallbacks] | None = None
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        logger=logger,
         model_name_or_path=config.model,
         hf_variant=config.hf_variant,
         base_embeddings=config.base_embeddings,

--- a/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion/textual_inversion/train.py
@@ -165,7 +165,7 @@ def train(config: SdTextualInversionConfig, callbacks: list[PipelineCallbacks] |
 
     logger.info("Loading models.")
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path=config.model, hf_variant=config.hf_variant, dtype=weight_dtype
+        logger=logger, model_name_or_path=config.model, hf_variant=config.hf_variant, dtype=weight_dtype
     )
 
     placeholder_tokens, placeholder_token_ids = _initialize_placeholder_tokens(

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora/train.py
@@ -360,6 +360,7 @@ def train(config: SdxlLoraConfig, callbacks: list[PipelineCallbacks] | None = No
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
+        logger=logger,
         model_name_or_path=config.model,
         hf_variant=config.hf_variant,
         vae_model=config.vae_model,

--- a/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/lora_and_textual_inversion/train.py
@@ -153,6 +153,7 @@ def train(config: SdxlLoraAndTextualInversionConfig, callbacks: list[PipelineCal
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
+        logger=logger,
         model_name_or_path=config.model,
         hf_variant=config.hf_variant,
         vae_model=config.vae_model,

--- a/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
+++ b/src/invoke_training/pipelines/stable_diffusion_xl/textual_inversion/train.py
@@ -191,7 +191,11 @@ def train(config: SdxlTextualInversionConfig, callbacks: list[PipelineCallbacks]
 
     logger.info("Loading models.")
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
-        model_name_or_path=config.model, hf_variant=config.hf_variant, vae_model=config.vae_model, dtype=weight_dtype
+        logger=logger,
+        model_name_or_path=config.model,
+        hf_variant=config.hf_variant,
+        vae_model=config.vae_model,
+        dtype=weight_dtype,
     )
 
     placeholder_tokens, placeholder_token_ids_1, placeholder_token_ids_2 = _initialize_placeholder_tokens(

--- a/tests/invoke_training/_shared/stable_diffusion/test_model_loading_utils.py
+++ b/tests/invoke_training/_shared/stable_diffusion/test_model_loading_utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,10 @@ from transformers import CLIPTextModel, CLIPTokenizer
 
 from invoke_training._shared.stable_diffusion.model_loading_utils import load_models_sd, load_models_sdxl
 
-from .ti_embedding_checkpoint_fixture import sdv1_embedding_path, sdxl_embedding_path  # noqa: F401
+from .ti_embedding_checkpoint_fixture import (  # noqa: F401
+    sdv1_embedding_path,
+    sdxl_embedding_path,
+)
 
 
 @pytest.mark.loads_model
@@ -14,6 +18,7 @@ def test_load_models_sd(sdv1_embedding_path):  # noqa: F811
     model_name = "runwayml/stable-diffusion-v1-5"
 
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
+        logger=logging.getLogger(__name__),
         model_name_or_path=model_name,
         hf_variant="fp16",
         base_embeddings={"special_test_token": str(sdv1_embedding_path)},
@@ -34,6 +39,7 @@ def test_load_models_sdxl(sdxl_embedding_path: Path):  # noqa: F811
     model_name = "stabilityai/stable-diffusion-xl-base-1.0"
 
     tokenizer_1, tokenizer_2, noise_scheduler, text_encoder_1, text_encoder_2, vae, unet = load_models_sdxl(
+        logger=logging.getLogger(__name__),
         model_name_or_path=model_name,
         hf_variant="fp16",
         base_embeddings={"special_test_token": str(sdxl_embedding_path)},

--- a/tests/invoke_training/_shared/stable_diffusion/test_textual_inversion.py
+++ b/tests/invoke_training/_shared/stable_diffusion/test_textual_inversion.py
@@ -31,7 +31,7 @@ def test_expand_placeholder_token_raises_on_invalid_num_vectors():
 @pytest.mark.loads_model
 def test_initialize_placeholder_tokens_from_initializer_token():
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+        logger=logging.getLogger(__name__), model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
     )
 
     initializer_token = "dog"
@@ -59,7 +59,7 @@ def test_initialize_placeholder_tokens_from_initializer_token():
 @pytest.mark.loads_model
 def test_initialize_placeholder_tokens_from_initial_phrase():
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+        logger=logging.getLogger(__name__), model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
     )
 
     initial_phrase = "little brown dog"
@@ -86,7 +86,7 @@ def test_initialize_placeholder_tokens_from_initial_phrase():
 @pytest.mark.loads_model
 def test_initialize_placeholder_tokens_from_initial_embedding(sdv1_embedding_path: Path):  # noqa: F811
     tokenizer, noise_scheduler, text_encoder, vae, unet = load_models_sd(
-        model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
+        logger=logging.getLogger(__name__), model_name_or_path="runwayml/stable-diffusion-v1-5", hf_variant="fp16"
     )
 
     placeholder_token = "custom_token"


### PR DESCRIPTION
As the title says, we try fallback variants when the initial variant fails. This improves redundancy, which is helpful in contexts where the cost of a failed pipeline is high.