### PR TITLE
Allow output file to be passed in during autocaptioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.aider*

--- a/src/invoke_training/scripts/_experimental/auto_caption/auto_caption_images.py
+++ b/src/invoke_training/scripts/_experimental/auto_caption/auto_caption_images.py
@@ -32,13 +32,13 @@ def process_images(images: list[Image.Image], prompt: str, moondream, tokenizer)
     return answers
 
 
-def main(image_dir: str, prompt: str, use_cpu: bool, batch_size: int):
+def main(image_dir: str, prompt: str, use_cpu: bool, batch_size: int, output_path: str):
     device, dtype = select_device_and_dtype(use_cpu)
     print(f"Using device: {device}")
     print(f"Using dtype: {dtype}")
 
     # Check that the output file does not already exist before spending time generating captions.
-    out_path = Path("output.jsonl")
+    out_path = Path(output_path)
     if out_path.exists():
         raise FileExistsError(f"Output file already exists: {out_path}")
 
@@ -99,6 +99,14 @@ if __name__ == "__main__":
         help="Batch size for processing images. To maximize speed, set this to the largest value that fits in GPU "
         "memory.",
     )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="output.jsonl",
+        help="(Optional) Path to the output file. Default is 'output.jsonl'.",
+    )
     args = parser.parse_args()
+
+    main(args.dir, args.prompt, args.cpu, args.batch_size, args.output)
 
     main(args.dir, args.prompt, args.cpu, args.batch_size)

--- a/src/invoke_training/scripts/_experimental/auto_caption/auto_caption_images.py
+++ b/src/invoke_training/scripts/_experimental/auto_caption/auto_caption_images.py
@@ -108,5 +108,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args.dir, args.prompt, args.cpu, args.batch_size, args.output)
-
-    main(args.dir, args.prompt, args.cpu, args.batch_size)


### PR DESCRIPTION
Currently, the output file of autocaptioning is hard-coded to be "output.jsonl". This small PR allows users to pass in a different output file location.