### PR TITLE
Fix pydantic `ValidationError` while creating dataset via the UI.

### DIFF
--- a/src/invoke_training/_shared/data/datasets/image_caption_jsonl_dataset.py
+++ b/src/invoke_training/_shared/data/datasets/image_caption_jsonl_dataset.py
@@ -15,7 +15,7 @@ MASK_COLUMN_DEFAULT = "mask"
 
 class ImageCaptionExample(BaseModel):
     image_path: str
-    mask_path: str | None
+    mask_path: str | None = None
     caption: str
 
 


### PR DESCRIPTION
Set default value for `ImageCaptionExample.mask_path`.

This fixes the following error:
```bash
pydantic_core._pydantic_core.ValidationError: 1 validation error for ImageCaptionExample
mask_path
  Field required [type=missing, input_value={'image_path': 'D:\\AI\\1...530.jpg', 'caption': ''}, input_type=dict]
```