### PR TITLE
fix(backend): Fixes Variantfp16 error for Diffusers format models

### DIFF
--- a/src/invoke_training/_shared/stable_diffusion/model_loading_utils.py
+++ b/src/invoke_training/_shared/stable_diffusion/model_loading_utils.py
@@ -94,8 +94,9 @@ def from_pretrained_with_variant_fallback(
                 variant=variant_to_try,
                 **kwargs,
             )
-        except OSError as e:
-            if "no file named" in str(e):
+        except (OSError, ValueError) as e:
+            error_str = str(e)
+            if "no file named" in error_str or "no such modeling files are available" in error_str:
                 # Ok; we'll try the variant fallbacks.
                 logger.warning(f"Failed to load '{model_name_or_path}' with variant '{variant_to_try}'. Error: {e}.")
             else:


### PR DESCRIPTION
## Summary

Fixes Variant fp16 error showing up in Diffusers files when variants aren't included in the directoy.
